### PR TITLE
Set the `alertSeverity` value

### DIFF
--- a/helm_deploy/manage-recalls-ui/values.yaml
+++ b/helm_deploy/manage-recalls-ui/values.yaml
@@ -56,3 +56,4 @@ generic-service:
 
 generic-prometheus-alerts:
   targetApplication: manage-recalls-ui
+  alertSeverity: ppud-replacement-alerts

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,7 +14,3 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
 
   allowlist:
-
-generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
-

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,7 +14,3 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
 
   allowlist:
-
-generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
-


### PR DESCRIPTION
This was given to us from the cloud platform team to be used so that
alerts are routed to us correctly...

ref:
- https://github.com/ministryofjustice/cloud-platform/issues/2926#issuecomment-852954702
- https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#create-a-prometheusrule