### PR TITLE
Add a context to the `check_outdated` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,9 @@ workflows:
               only:
                 - main
     jobs:
-      - check_outdated
+      - check_outdated:
+          context:
+            - hmpps-common-vars
       - hmpps/npm_security_audit:
           context:
             - hmpps-common-vars


### PR DESCRIPTION
This includes the SLACK_ACCESS_TOKEN environment variable needed for
slack notifications.