### PR TITLE
Separate the build/publish docker steps and scan with Trivy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
             mkdir -p docker_cache
             docker save ${IMAGE_TAG} -o docker_cache/build_image.tar
       - persist_to_workspace:
-          root: .
+          root: ~/app
           paths:
             - docker_cache
       - mem/remember:
@@ -185,17 +185,22 @@ jobs:
   trivy_scan:
     executor: docker
     steps:
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
           name: Install trivy
           command: |
-            apk add --update-cache --upgrade curl
-            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp
+      - attach_workspace:
+          at: ~/app
       - run:
           name: "Trivy scan for UNKNOWN,LOW,MEDIUM CVEs - informational, WILL NOT fail build"
           command: |
-            trivy image \
+            pwd
+            ls -l
+            ls -l docker_cache
+            /tmp/trivy image \
               --exit-code 0 \
               --no-progress \
               --severity UNKNOWN,LOW,MEDIUM \
@@ -204,7 +209,7 @@ jobs:
       - run:
           name: "Trivy scan for HIGH,CRITICAL CVEs - WILL fail build"
           command: |
-            trivy image \
+            /tmp/trivy image \
               --exit-code 1 \
               --no-progress \
               --severity HIGH,CRITICAL \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,39 +182,60 @@ jobs:
           env_var: IMAGE_TAG
           value: "${IMAGE_TAG}"
 
+  publish_docker:
+    executor: docker
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: ~/app
+      - run:
+          name: Extract saved container image
+          command: docker load --input docker_cache/build_image.tar
+      - mem/recall:
+          env_var: IMAGE_TAG
+      - run:
+          name: Publish image to repository
+          command: |
+            docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io
+            docker tag "${IMAGE_TAG}" "<< pipeline.parameters.docker-image-name >>:latest"
+            docker push "${IMAGE_TAG}"
+            docker push "<< pipeline.parameters.docker-image-name >>:latest"
+
   trivy_scan:
     executor: docker
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
+      - attach_workspace:
+          at: ~/app
+      - run:
+          name: Extract saved container image
+          command: docker load --input docker_cache/build_image.tar
+      - mem/recall:
+          env_var: IMAGE_TAG
       - run:
           name: Install trivy
           command: |
             curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp
-      - attach_workspace:
-          at: ~/app
       - run:
           name: "Trivy scan for UNKNOWN,LOW,MEDIUM CVEs - informational, WILL NOT fail build"
           command: |
-            pwd
-            ls -l
-            ls -l docker_cache
             /tmp/trivy image \
               --exit-code 0 \
               --no-progress \
               --severity UNKNOWN,LOW,MEDIUM \
               --ignore-unfixed \
-              --input docker_cache/build_image.tar
+              "${IMAGE_TAG}"
       - run:
           name: "Trivy scan for HIGH,CRITICAL CVEs - WILL fail build"
           command: |
             /tmp/trivy image \
-              --exit-code 1 \
+              --exit-code 100 \
               --no-progress \
               --severity HIGH,CRITICAL \
               --ignore-unfixed \
-              --input docker_cache/build_image.tar
+              "${IMAGE_TAG}"
 
 workflows:
   version: 2
@@ -242,10 +263,7 @@ workflows:
           requires:
             - build_docker
 
-      - hmpps/build_docker:
-          name: publish_docker
-          image_name: << pipeline.parameters.docker-image-name >>
-          publish: true
+      - publish_docker:
           requires:
             - trivy_scan
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,16 +139,26 @@ workflows:
         filters:
           tags:
             ignore: /.*/
+
       - unit_test:
           requires:
             - build
+
       - integration_test:
           requires:
             - build
+
       - hmpps/helm_lint:
           name: helm_lint
+
       - hmpps/build_docker:
           name: build_docker
+          publish: false
+
+      - hmpps/build_docker:
+          name: publish_docker
+          requires:
+            - build_docker
           filters:
             branches:
               only:
@@ -166,7 +176,7 @@ workflows:
             - helm_lint
             - unit_test
             - integration_test
-            - build_docker
+            - publish_docker
 
       - request-preprod-approval:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,14 @@ executors:
       - image: cimg/node:14.15-browsers
       - image: circleci/redis:buster
     working_directory: ~/app
+  trivy:
+    docker:
+      - image: docker:stable-git
 
 parameters:
+  docker-image-name:
+    type: string
+    default: quay.io/hmpps/${CIRCLE_PROJECT_REPONAME}
   alerts-slack-channel:
     type: string
     default: ppud-replacement-devs
@@ -131,6 +137,35 @@ jobs:
       - store_artifacts:
           path: integration-tests/screenshots
 
+  trivy_scan:
+    executor: trivy
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Install trivy
+          command: |
+            apk add --update-cache --upgrade curl
+            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+      - run:
+          name: "Trivy scan for UNKNOWN,LOW,MEDIUM CVEs - informational, WILL NOT fail build"
+          command: |
+            trivy \
+              --exit-code 0 \
+              --no-progress \
+              --severity UNKNOWN,LOW,MEDIUM \
+              --ignore-unfixed \
+              << pipeline.parameters.docker-image-name >>
+      - run:
+          name: "Trivy scan for HIGH,CRITICAL CVEs - WILL fail build"
+          command: |
+            trivy \
+              --exit-code 1 \
+              --no-progress \
+              --severity HIGH,CRITICAL \
+              --ignore-unfixed \
+              << pipeline.parameters.docker-image-name >>
+
 workflows:
   version: 2
   build-test-and-deploy:
@@ -154,11 +189,16 @@ workflows:
       - hmpps/build_docker:
           name: build_docker
           publish: false
+          image_name: << pipeline.parameters.docker-image-name >>
+
+      - trivy_scan:
+          requires:
+            - build_docker
 
       - hmpps/build_docker:
           name: publish_docker
           requires:
-            - build_docker
+            - trivy_scan
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hmpps: ministryofjustice/hmpps@3.2
+  mem: circleci/rememborb@0.0.2
   slack: circleci/slack@4.4.2
 
 executors:
@@ -10,9 +11,10 @@ executors:
       - image: cimg/node:14.15-browsers
       - image: circleci/redis:buster
     working_directory: ~/app
-  trivy:
+  docker:
     docker:
-      - image: docker:stable-git
+      - image: cimg/python:3.9
+    working_directory: ~/app
 
 parameters:
   docker-image-name:
@@ -137,8 +139,51 @@ jobs:
       - store_artifacts:
           path: integration-tests/screenshots
 
+  build_docker:
+    executor: docker
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Create app version string
+          command: |
+            DATE=$(date '+%Y-%m-%d')
+            SHORT_SHA1=$(echo $CIRCLE_SHA1 | cut -c1-7)
+            VERSION=${DATE}.${CIRCLE_BUILD_NUM}.${SHORT_SHA1}
+            echo "Created version string: ${VERSION}"
+            echo "export APP_VERSION=$VERSION" >> $BASH_ENV
+      - run:
+          name: Build container image
+          command: |
+            IMAGE_TAG=<< pipeline.parameters.docker-image-name >>:${APP_VERSION}
+            echo "export IMAGE_TAG=$IMAGE_TAG" >> $BASH_ENV
+            docker build --pull \
+              --rm=false . \
+              --build-arg BUILD_NUMBER=$APP_VERSION \
+              --build-arg GIT_REF=$CIRCLE_SHA1 \
+              --tag "${IMAGE_TAG}" \
+              --label "maintainer=dps-hmpps@digital.justice.gov.uk" \
+              --label "app.version=${APP_VERSION}" \
+              --label "build.version=${APP_VERSION}" \
+              --label "build.number=${CIRCLE_BUILD_NUM}" \
+              --label "build.url=${CIRCLE_BUILD_URL}" \
+              --label "build.gitref=${CIRCLE_SHA1}"
+      - run:
+          name: Save container image
+          command: |
+            mkdir -p docker_cache
+            docker save ${IMAGE_TAG} -o docker_cache/build_image.tar
+      - persist_to_workspace:
+          root: .
+          paths:
+            - docker_cache
+      - mem/remember:
+          env_var: IMAGE_TAG
+          value: "${IMAGE_TAG}"
+
   trivy_scan:
-    executor: trivy
+    executor: docker
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -150,21 +195,21 @@ jobs:
       - run:
           name: "Trivy scan for UNKNOWN,LOW,MEDIUM CVEs - informational, WILL NOT fail build"
           command: |
-            trivy \
+            trivy image \
               --exit-code 0 \
               --no-progress \
               --severity UNKNOWN,LOW,MEDIUM \
               --ignore-unfixed \
-              << pipeline.parameters.docker-image-name >>
+              --input docker_cache/build_image.tar
       - run:
           name: "Trivy scan for HIGH,CRITICAL CVEs - WILL fail build"
           command: |
-            trivy \
+            trivy image \
               --exit-code 1 \
               --no-progress \
               --severity HIGH,CRITICAL \
               --ignore-unfixed \
-              << pipeline.parameters.docker-image-name >>
+              --input docker_cache/build_image.tar
 
 workflows:
   version: 2
@@ -186,10 +231,7 @@ workflows:
       - hmpps/helm_lint:
           name: helm_lint
 
-      - hmpps/build_docker:
-          name: build_docker
-          publish: false
-          image_name: << pipeline.parameters.docker-image-name >>
+      - build_docker
 
       - trivy_scan:
           requires:
@@ -197,6 +239,8 @@ workflows:
 
       - hmpps/build_docker:
           name: publish_docker
+          image_name: << pipeline.parameters.docker-image-name >>
+          publish: true
           requires:
             - trivy_scan
           filters:


### PR DESCRIPTION
This introduces CVE scanning of both the OS packages and the NPM dependencies prior to publishing the images.

If we're happy with this setup (give it a week or so) I can look at porting it to the HMPPS orb so it's usable in future templated apps.