### PR TITLE
DISABLE TRIVY SCAN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,7 @@ workflows:
             - helm_lint
             - integration_test
 #            - trivy_scan
+            - build_docker #needs removing when trivy re-enabled
             - unit_test
           filters:
             branches:


### PR DESCRIPTION
add build-docker as dependency of publish-docker whilst Trivy removed