### PR TITLE
Add the needed ingress annotations for cluster migration.

### DIFF
--- a/helm_deploy/manage-recalls-ui/Chart.yaml
+++ b/helm_deploy/manage-recalls-ui/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 
 dependencies:
   - name: generic-service
-    version: 1.0.12
+    version: 1.0.16
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 0.2.5

--- a/helm_deploy/manage-recalls-ui/values.yaml
+++ b/helm_deploy/manage-recalls-ui/values.yaml
@@ -13,7 +13,6 @@ generic-service:
     enabled: true
     host: app-hostname.local    # override per environment
     tlsSecretName: manage-recalls-ui-cert
-    path: /
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,6 +7,8 @@ generic-service:
   ingress:
     host: manage-recalls-dev.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-dev-cert
+    # which cluster are we on: live-1 is blue, live is green
+    contextColour: blue
 
   env:
     INGRESS_URL: "https://manage-recalls-dev.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,6 +7,8 @@ generic-service:
   ingress:
     host: manage-recalls-preprod.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-preprod-cert
+    # which cluster are we on: live-1 is blue, live is green
+    contextColour: blue
 
   env:
     INGRESS_URL: "https://manage-recalls-preprod.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,6 +7,8 @@ generic-service:
   ingress:
     host: manage-recalls.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-prod-cert
+    # which cluster are we on: live-1 is blue, live is green
+    contextColour: blue
 
   env:
     INGRESS_URL: "https://manage-recalls.hmpps.service.justice.gov.uk"


### PR DESCRIPTION
ref: https://mojdt.slack.com/archives/CH6D099DF/p1633679858013800

This bump in the generic-service template adds in the needed
annotations requested by the cloud platform team. When the time comes to
move our apps onto the new "live" cluster the contextColor directive
will allow us to switch traffic (but it doesn't impact deployment,
that's another story).