### PR TITLE
PUD-738 - Continue assessment from to do list

### DIFF
--- a/integration_tests/integration/assess-recall.spec.js
+++ b/integration_tests/integration/assess-recall.spec.js
@@ -35,6 +35,7 @@ context('Assess a recall', () => {
     cy.task('expectGetRecall', { recallId, expectedResult: { ...getRecallResponse, recallId, status: 'BOOKED_ON' } })
     cy.task('expectUpdateRecall', recallId)
     cy.task('expectAddRecallDocument', { statusCode: 201 })
+    cy.task('expectAssignAssessment', { expectedResult: getRecallResponse })
     cy.task('expectGetUserDetails', { firstName: 'Bertie', lastName: 'Badger' })
     cy.task('expectRefData', { refDataPath: 'local-delivery-units', expectedResult: getLocalDeliveryUnitsResponse })
     cy.task('expectRefData', { refDataPath: 'prisons', expectedResult: getPrisonsResponse })

--- a/integration_tests/integration/find-person.spec.js
+++ b/integration_tests/integration/find-person.spec.js
@@ -1,4 +1,4 @@
-import { searchResponse, getRecallsResponse } from '../mockApis/mockResponses'
+import { searchResponse, getRecallsResponse, getRecallResponse } from '../mockApis/mockResponses'
 import recallPreConsNamePage from '../pages/recallPreConsName'
 import assessRecallPage from '../pages/assessRecall'
 import dossierRecallInformationPage from '../pages/dossierRecallInformation'
@@ -47,6 +47,7 @@ context('Find a person', () => {
     cy.task('expectListRecalls', { expectedResults: [] })
     cy.task('expectGetRecall', { expectedResult: { recallId, documents: [] } })
     cy.task('expectSearchRecalls', { expectedSearchTerm: nomsNumber, expectedResults: getRecallsResponse })
+    cy.task('expectAssignAssessment', { expectedResult: getRecallResponse })
     cy.login()
     const homePage = findOffenderPage.verifyOnPage(nomsNumber)
     const firstResult = homePage.searchResults().first()

--- a/integration_tests/integration/todo-recalls-list.spec.js
+++ b/integration_tests/integration/todo-recalls-list.spec.js
@@ -1,4 +1,4 @@
-import { searchResponse } from '../mockApis/mockResponses'
+import { getRecallResponse, searchResponse } from '../mockApis/mockResponses'
 import recallsListPage from '../pages/recallsList'
 import assessRecallPage from '../pages/assessRecall'
 import dossierRecallInformationPage from '../pages/dossierRecallInformation'
@@ -49,10 +49,33 @@ context('To do (recalls) list', () => {
         },
       ],
     })
+    cy.task('expectAssignAssessment', { expectedResult: getRecallResponse })
     cy.login()
     const recallsList = recallsListPage.verifyOnPage()
     recallsList.expectActionLinkText({ id: `assess-recall-${recallId}`, text: 'Assess recall' })
     recallsList.assessRecall({ recallId })
+    assessRecallPage.verifyOnPage({ fullName: personName })
+  })
+
+  it('User can continue assessment if the recall has status IN_ASSESSMENT', () => {
+    cy.task('expectListRecalls', {
+      expectedResults: [
+        {
+          recallId,
+          nomsNumber,
+          status: 'IN_ASSESSMENT',
+          recallAssessmentDueDateTime: '2021-10-12T14:30:52Z',
+          assignee: '122',
+          assigneeUserName: 'Jimmy Pud',
+        },
+      ],
+    })
+    cy.login()
+    const recallsList = recallsListPage.verifyOnPage()
+    recallsList.assertElementHasText({ qaAttr: 'dueDate', textToFind: '12 October 2021 at 15:30' })
+    recallsList.assertElementHasText({ qaAttr: 'assignedTo', textToFind: 'Jimmy Pud' })
+    recallsList.expectActionLinkText({ id: `continue-assess-${recallId}`, text: 'Continue assessment' })
+    recallsList.continueAssessment({ recallId })
     assessRecallPage.verifyOnPage({ fullName: personName })
   })
 

--- a/integration_tests/mockApis/manageRecallsApi.js
+++ b/integration_tests/mockApis/manageRecallsApi.js
@@ -175,6 +175,21 @@ export default function manageRecallsApi(wiremock) {
         },
       })
     },
+    expectAssignAssessment: expectation => {
+      return wiremock.stubFor({
+        request: {
+          method: 'POST',
+          urlPattern: `/recalls/(.*)/assignee/(.*)`,
+        },
+        response: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json;charset=UTF-8',
+          },
+          jsonBody: expectation.expectedResult,
+        },
+      })
+    },
     stubPing: () => {
       return wiremock.stubFor({
         request: {

--- a/integration_tests/pages/recallsList.js
+++ b/integration_tests/pages/recallsList.js
@@ -14,6 +14,7 @@ const recallsListPage = () =>
     },
     continueBooking: ({ recallId }) => cy.get(`[data-qa=continue-booking-${recallId}]`).click(),
     assessRecall: ({ recallId }) => cy.get(`[data-qa=assess-recall-${recallId}]`).click(),
+    continueAssessment: ({ recallId }) => cy.get(`[data-qa=continue-assess-${recallId}]`).click(),
     createDossier: ({ recallId }) => cy.get(`[data-qa=create-dossier-${recallId}]`).click(),
     viewRecall: ({ recallId }) => cy.get(`[data-qa=view-recall-${recallId}]`).click(),
   })

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -35,6 +35,7 @@ module.exports = (on, config) => {
     expectUpdateRecall: manageRecallsApi.expectUpdateRecall,
     expectGetRecallDocument: manageRecallsApi.expectGetRecallDocument,
     expectGetUserDetails: manageRecallsApi.expectGetUserDetails,
+    expectAssignAssessment: manageRecallsApi.expectAssignAssessment,
     expectRefData: manageRecallsApi.expectRefData,
     readPdf: readPdf.readPdf,
   })

--- a/server/@types/index.d.ts
+++ b/server/@types/index.d.ts
@@ -152,9 +152,8 @@ export interface EmailUploadValidatorArgs {
 }
 
 export interface RecallResult {
-  recallId: string
-  status: string
-  offender: PersonSearchResult
+  recall: RecallResponse
+  person: PersonSearchResult
 }
 
 export type DateValidationErrorType =

--- a/server/routes/handlers/assess/assignAssessment.test.ts
+++ b/server/routes/handlers/assess/assignAssessment.test.ts
@@ -1,0 +1,63 @@
+import nock from 'nock'
+import { mockPostRequest, mockResponseWithAuthenticatedUser } from '../../testutils/mockRequestUtils'
+import * as config from '../../../config'
+import { assignAssessment } from './assignAssessment'
+import { ApiConfig } from '../../../config'
+
+const userToken = { access_token: 'token-1', expires_in: 300 }
+
+describe('assignAssessment', () => {
+  let fakeManageRecallsApi: nock.Scope
+
+  beforeEach(() => {
+    fakeManageRecallsApi = nock(config.default.apis.manageRecallsApi.url)
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should redirect to the assess recall page', async () => {
+    const recallId = '123'
+    const nomsNumber = '123ABC'
+    const userId = '123'
+
+    fakeManageRecallsApi
+      .post(`/recalls/${recallId}/assignee/${userId}`)
+      .matchHeader('authorization', `Bearer ${userToken.access_token}`)
+      .reply(200, { recallId })
+
+    const req = mockPostRequest({ params: { nomsNumber, recallId } })
+    const { res } = mockResponseWithAuthenticatedUser(userToken.access_token)
+    res.locals.user.uuid = userId
+    res.locals.urlInfo = {
+      basePath: `/persons/${nomsNumber}/recalls/${recallId}/`,
+    }
+
+    await assignAssessment(req, res)
+
+    expect(res.redirect).toHaveBeenCalledWith(303, `/persons/${nomsNumber}/recalls/${recallId}/assess`)
+  })
+
+  it('should reload the page if the assignment fails', async () => {
+    const recallId = '123'
+    const nomsNumber = '123ABC'
+    const userId = '123'
+    jest.spyOn(config, 'manageRecallsApiConfig').mockReturnValue({ timeout: { response: 1, deadline: 1 } } as ApiConfig)
+    fakeManageRecallsApi
+      .post(`/recalls/${recallId}/assignee/${userId}`)
+      .matchHeader('authorization', `Bearer ${userToken.access_token}`)
+      .reply(500)
+
+    const req = mockPostRequest({ params: { nomsNumber, recallId } })
+    const { res } = mockResponseWithAuthenticatedUser(userToken.access_token)
+    res.locals.user.uuid = userId
+    res.locals.urlInfo = {
+      basePath: `/persons/${nomsNumber}/recalls/${recallId}/`,
+    }
+
+    await assignAssessment(req, res)
+
+    expect(res.redirect).toHaveBeenCalledWith(303, '/')
+  })
+})

--- a/server/routes/handlers/assess/assignAssessment.ts
+++ b/server/routes/handlers/assess/assignAssessment.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from 'express'
+import { assignAssessingUser } from '../../../clients/manageRecallsApi/manageRecallsApiClient'
+
+export const assignAssessment = async (req: Request, res: Response): Promise<void> => {
+  const { recallId } = req.params
+  const { user, urlInfo } = res.locals
+  try {
+    await assignAssessingUser(recallId, user.uuid, user.token)
+    res.redirect(303, `${urlInfo.basePath}assess`)
+  } catch (err) {
+    req.session.errors = [
+      {
+        name: 'saveError',
+        text: 'An error occurred assigning you to the recall assessment',
+      },
+    ]
+    res.redirect(303, '/')
+  }
+}

--- a/server/routes/handlers/helpers/viewWithRecallAndPerson.test.ts
+++ b/server/routes/handlers/helpers/viewWithRecallAndPerson.test.ts
@@ -151,7 +151,9 @@ describe('viewWithRecallAndPerson', () => {
     const req = mockGetRequest({ params: { recallId, nomsNumber } })
     const { res } = mockResponseWithAuthenticatedUser(accessToken)
     await viewWithRecallAndPerson('assessRecall')(req, res)
-    expect(res.locals.recallAssessmentDueText).toEqual('Overdue: recall assessment was due on 6 August 2020 by 16:33')
+    expect(res.locals.recall.recallAssessmentDueText).toEqual(
+      'Overdue: recall assessment was due on 6 August 2020 by 16:33'
+    )
     expect(res.render).toHaveBeenCalledWith('pages/assessRecall')
   })
 })

--- a/server/routes/handlers/helpers/viewWithRecallAndPerson.ts
+++ b/server/routes/handlers/helpers/viewWithRecallAndPerson.ts
@@ -44,8 +44,8 @@ export const viewWithRecallAndPerson =
     res.locals.recall.previousConvictionMainName =
       recall.previousConvictionMainName || `${res.locals.person.firstName} ${res.locals.person.lastName}`
 
-    res.locals.recallAssessmentDueText = recallAssessmentDueText(recall.recallAssessmentDueDateTime)
-    res.locals.dossierDueText = dossierDueDateString(recall.dossierTargetDate)
+    res.locals.recall.recallAssessmentDueText = recallAssessmentDueText(recall.recallAssessmentDueDateTime)
+    res.locals.recall.dossierDueText = dossierDueDateString(recall.dossierTargetDate)
 
     if (requiresUser(viewName)) {
       const userNames = await getUserNames(res.locals.recall, res.locals.user.token)

--- a/server/routes/handlers/recallList.test.ts
+++ b/server/routes/handlers/recallList.test.ts
@@ -14,6 +14,12 @@ describe('recallList', () => {
 
   beforeEach(() => {
     fakeManageRecallsApi.get('/recalls').reply(200, recalls)
+    req = mockGetRequest({})
+    const { res } = mockResponseWithAuthenticatedUser(userToken.access_token)
+    resp = res
+  })
+
+  it('should make recalls with person details available to render', async () => {
     fakeManageRecallsApi
       .post('/search')
       .times(recalls.length)
@@ -23,36 +29,50 @@ describe('recallList', () => {
           lastName: 'Badger',
         },
       ])
-    req = mockGetRequest({})
-    const { res } = mockResponseWithAuthenticatedUser(userToken.access_token)
-    resp = res
+    await recallList(req, resp)
+    expect(resp.locals.results).toEqual([
+      {
+        person: {
+          firstName: 'Bobby',
+          lastName: 'Badger',
+        },
+        recall: {
+          nomsNumber: '123',
+          recallId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+          status: 'BOOKED_ON',
+        },
+      },
+      {
+        person: {
+          firstName: 'Bobby',
+          lastName: 'Badger',
+        },
+        recall: {
+          nomsNumber: '123',
+          recallId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        },
+      },
+      {
+        person: {
+          firstName: 'Bobby',
+          lastName: 'Badger',
+        },
+        recall: {
+          nomsNumber: '456',
+          recallId: '8ab377a6-4587-2598-abc4-98fc53737',
+          status: 'RECALL_NOTIFICATION_ISSUED',
+        },
+      },
+    ])
   })
 
-  it('should make recalls with person details available to render', async () => {
+  it('should make a list of failed recall requests available to render', async () => {
+    fakeManageRecallsApi.post('/search').times(recalls.length).reply(404)
     await recallList(req, resp)
-    expect(resp.locals.recalls).toEqual([
+    expect(resp.locals.errors).toEqual([
       {
-        offender: {
-          firstName: 'Bobby',
-          lastName: 'Badger',
-        },
-        recallId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-        status: 'BOOKED_ON',
-      },
-      {
-        offender: {
-          firstName: 'Bobby',
-          lastName: 'Badger',
-        },
-        recallId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-      },
-      {
-        offender: {
-          firstName: 'Bobby',
-          lastName: 'Badger',
-        },
-        recallId: '8ab377a6-4587-2598-abc4-98fc53737',
-        status: 'RECALL_NOTIFICATION_ISSUED',
+        name: 'fetchError',
+        text: '3 recalls could not be retrieved',
       },
     ])
   })

--- a/server/routes/handlers/recallList.ts
+++ b/server/routes/handlers/recallList.ts
@@ -14,9 +14,8 @@ export const recallList = async (req: Request, res: Response): Promise<Response 
         searchByNomsNumber(recall.nomsNumber, token).then(
           person =>
             <RecallResult>{
-              recallId: recall.recallId,
-              status: recall.status,
-              offender: person,
+              recall,
+              person,
             }
         )
       )
@@ -29,9 +28,14 @@ export const recallList = async (req: Request, res: Response): Promise<Response 
       }
     })
   }
-  res.locals.recalls = successful
-  // TODO - report to user that some recalls couldn't be retrieved
-  res.locals.errors = failed
+  res.locals.results = successful
+  if (failed.length) {
+    res.locals.errors = res.locals.errors || []
+    res.locals.errors.push({
+      name: 'fetchError',
+      text: `${failed.length} recalls could not be retrieved`,
+    })
+  }
   res.locals.isTodoPage = true
   res.render('pages/recallList')
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -30,6 +30,7 @@ import { validateCheckAnswers } from './handlers/book/helpers/validateCheckAnswe
 import { getUser, postUser } from './handlers/user/userDetails'
 import { parseUrlParams } from '../middleware/parseUrlParams'
 import { fetchRemoteRefData } from '../referenceData'
+import { assignAssessment } from './handlers/assess/assignAssessment'
 
 export default function routes(router: Router): Router {
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
@@ -72,6 +73,7 @@ export default function routes(router: Router): Router {
   get(`${basePath}/confirmation`, viewWithRecallAndPerson('recallConfirmation'))
 
   // ASSESS A RECALL
+  post(`${basePath}/assess-assign`, assignAssessment)
   get(`${basePath}/assess`, viewWithRecallAndPerson('assessRecall'))
   get(`${basePath}/assess-decision`, viewWithRecallAndPerson('assessDecision'))
   post(`${basePath}/assess-decision`, handleRecallFormPost(validateDecision, 'assess-licence'))

--- a/server/views/pages/assessRecall.njk
+++ b/server/views/pages/assessRecall.njk
@@ -15,7 +15,7 @@
                     Recall information
                 </div>
             </h1>
-            <div class="govuk-body-l" data-qa="recallAssessmentDueText">{{ recallAssessmentDueText }}</div>
+            <div class="govuk-body-l" data-qa="recallAssessmentDueText">{{ recall.recallAssessmentDueText }}</div>
         </div>
     </div>
 

--- a/server/views/pages/dossierRecallInformation.njk
+++ b/server/views/pages/dossierRecallInformation.njk
@@ -21,7 +21,7 @@
                     Recall information
                 </div>
             </h1>
-            <div class="govuk-body-l" data-qa="dossierTargetDate">{{ dossierDueText }} {{ recall.dossierTargetDate | dateTime }} </div>
+            <div class="govuk-body-l" data-qa="dossierTargetDate">{{ recall.dossierDueText }} {{ recall.dossierTargetDate | dateTime }} </div>
         </div>
     </div>
 

--- a/server/views/pages/recallList.njk
+++ b/server/views/pages/recallList.njk
@@ -6,41 +6,51 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
+            {% if errors %}
+                {{ govukErrorSummary({
+                    titleText: "There is a problem",
+                    errorList: errors.list,
+                    attributes: {
+                        'data-qa': 'error-list'
+                    }
+                }) }}
+            {% endif %}
             <h1 class="govuk-heading-l">
                 To do
             </h1>
-
-            {% if recalls %}
-                {% if recalls.length > 0 %}
-                    <table class="govuk-table">
-                        <caption class="govuk-table__caption govuk-table__caption--m" data-qa="recalls-list-heading">
-                            <span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>{{ recalls.length }}</span> recall{% if recalls.length > 1 %}s{% endif %}
-                        </caption>
-                        <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th scope="col" class="govuk-table__header">Recall ID</th>
-                            <th scope="col" class="govuk-table__header">Name</th>
-                            <th scope="col" class="govuk-table__header">Recall date</th>
-                            <th scope="col" class="govuk-table__header">Due date</th>
-                            <th scope="col" class="govuk-table__header"><span class='govuk-visually-hidden'>View recall details</span></th>
+            {% if results and results.length > 0 %}
+                <table class="govuk-table">
+                    <caption class="govuk-table__caption govuk-table__caption--m" data-qa="recalls-list-heading">
+                        <span class='govuk-!-font-size-36 govuk-!-font-weight-bold'>{{ results.length }}</span>
+                        recall{% if results.length > 1 %}s{% endif %}
+                    </caption>
+                    <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Recall ID</th>
+                        <th scope="col" class="govuk-table__header">Name</th>
+                        <th scope="col" class="govuk-table__header">Due</th>
+                        <th scope="col" class="govuk-table__header">Assigned to</th>
+                        <th scope="col" class="govuk-table__header">Action</th>
+                    </tr>
+                    </thead>
+                    <tbody class="govuk-table__body" data-qa="search-results">
+                    {% for result in results %}
+                        <tr class="govuk-table__row" data-qa='recall-id-{{ result.recall.recallId }}'>
+                            <td class="govuk-table__cell" data-qa="recallId">{{ result.recall.recallId }}</td>
+                            <td class="govuk-table__cell"
+                                data-qa="name">{{ result.person.firstName }} {{ result.person.lastName }}</td>
+                            <td class="govuk-table__cell"
+                                data-qa="dueDate">{{ result.recall.recallAssessmentDueDateTime | dateTime }}</td>
+                            <td class="govuk-table__cell" data-qa="assignedTo">{{ result.recall.assigneeUserName }}</td>
+                            <td class="govuk-table__cell">
+                                {% set person = result.person %}
+                                {% set recall = result.recall %}
+                                {% include "../partials/recallActionLink.njk" %}
+                            </td>
                         </tr>
-                        </thead>
-                        <tbody class="govuk-table__body" data-qa="search-results">
-                        {% for recall in recalls %}
-                            <tr class="govuk-table__row" data-qa='recall-id-{{ recall.recallId }}'>
-                                <td class="govuk-table__cell" data-qa="recallId">{{ recall.recallId }}</td>
-                                <td class="govuk-table__cell" data-qa="name">{{ recall.offender.firstName }} {{ recall.offender.lastName }}</td>
-                                <td class="govuk-table__cell" data-qa="recallDate">{{ recall.offender.recallDate }}</td>
-                                <td class="govuk-table__cell" data-qa="dueDate">{{ recall.offender.dueDate }}</td>
-                                <td class="govuk-table__cell">
-                                    {% set person = recall.offender %}
-                                    {% include "../partials/recallActionLink.njk" %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                {% endif %}
+                    {% endfor %}
+                    </tbody>
+                </table>
             {% endif %}
         </div>
     </div>

--- a/server/views/partials/recallActionLink.njk
+++ b/server/views/partials/recallActionLink.njk
@@ -1,5 +1,14 @@
 {% if recall.status == 'BOOKED_ON' %}
-<div><a href='/persons/{{person.nomsNumber}}/recalls/{{recall.recallId}}/assess' data-qa='assess-recall-{{ recall.recallId }}'>Assess recall</a></div>
+<div>
+    <form novalidate action="/persons/{{ person.nomsNumber }}/recalls/{{ recall.recallId }}/assess-assign" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <button class="govuk-link reset-button link-button" data-module="govuk-button" data-qa="assess-recall-{{ recall.recallId }}">
+            Assess recall
+        </button>
+    </form>
+</div>
+{% elif recall.status == 'IN_ASSESSMENT' %}
+<div><a href='/persons/{{person.nomsNumber}}/recalls/{{recall.recallId}}/assess' data-qa='continue-assess-{{ recall.recallId }}'>Continue assessment</a></div>
 {% elif recall.status == 'RECALL_NOTIFICATION_ISSUED' %}
 <div><a href='/persons/{{person.nomsNumber}}/recalls/{{recall.recallId}}/dossier-recall' data-qa='create-dossier-{{ recall.recallId }}'>Create dossier</a></div>
 {% elif recall.status == 'DOSSIER_ISSUED' %}


### PR DESCRIPTION
- when 'assess recall' is clicked on to do list, save the assigned user to the API
- display assigned users on to do list

Also -
- for existing due dates, move formatted strings under recall object in res.locals