### PR TITLE
PUD-738 - Don't make unassign call in parallel with update recall call

### DIFF
--- a/server/routes/handlers/helpers/emailUploadForm.ts
+++ b/server/routes/handlers/helpers/emailUploadForm.ts
@@ -71,13 +71,11 @@ export const emailUploadForm =
           req.session.unsavedValues = unsavedValues
           return res.redirect(303, req.originalUrl)
         }
-        const [updateResult, unassignResult] = await Promise.allSettled([
-          updateRecall(recallId, valuesToSave, user.token),
-          unassignAssessingUser ? unassignAssessingUser(recallId, user.uuid, user.token) : undefined,
-        ])
-        if (updateResult.status === 'fulfilled' && unassignResult.status === 'fulfilled') {
-          return res.redirect(303, `${urlInfo.basePath}${urlInfo.fromPage || nextPageUrlSuffix}`)
+        await updateRecall(recallId, valuesToSave, user.token)
+        if (unassignAssessingUser) {
+          await unassignAssessingUser(recallId, user.uuid, user.token)
         }
+        return res.redirect(303, `${urlInfo.basePath}${urlInfo.fromPage || nextPageUrlSuffix}`)
         throw new Error('Recall update or unassign failed')
       } catch (e) {
         logger.error(e)


### PR DESCRIPTION
There's an existing unit test for this function that checked for the call to unassign, so didn't need updating - https://github.com/ministryofjustice/manage-recalls-ui/blob/main/server/routes/handlers/helpers/emailUploadForm.test.ts#L205-L242
