### PR TITLE
PUD-968 - person search cache

### DIFF
--- a/server/routes/handlers/helpers/personCache.test.ts
+++ b/server/routes/handlers/helpers/personCache.test.ts
@@ -79,4 +79,15 @@ describe('Get person data from cache', () => {
     await getPerson('1', token)
     expect(redisExports.getRedisAsync).not.toHaveBeenCalled()
   })
+
+  it('should return basic person details if cache is empty and API errors', async () => {
+    jest.spyOn(redisExports, 'getRedisAsync').mockResolvedValue(null)
+    ;(searchByNomsNumber as jest.Mock).mockRejectedValue(new Error('Timeout'))
+    const person = await getPerson('1', token, true)
+    expect(person).toEqual({
+      firstName: '<first name>',
+      lastName: '<last name>',
+      nomsNumber: '1',
+    })
+  })
 })

--- a/server/routes/handlers/helpers/personCache.ts
+++ b/server/routes/handlers/helpers/personCache.ts
@@ -11,18 +11,27 @@ const fetchPersonFromApiAndCache = async (
   token: string,
   useCache?: boolean
 ): Promise<PersonSearchResult | null> =>
-  searchByNomsNumber(nomsNumber, token).then(person => {
-    if (person && useCache) {
-      try {
-        const redisClient = getRedisClient()
-        redisClient.set(getKey(nomsNumber), JSON.stringify(person))
-        redisClient.expire(getKey(nomsNumber), config.personCache.ttl)
-      } catch (err) {
-        logger.error(err)
+  searchByNomsNumber(nomsNumber, token)
+    .then(person => {
+      if (person && useCache) {
+        try {
+          const redisClient = getRedisClient()
+          redisClient.set(getKey(nomsNumber), JSON.stringify(person))
+          redisClient.expire(getKey(nomsNumber), config.personCache.ttl)
+        } catch (err) {
+          logger.error(err)
+        }
       }
-    }
-    return person
-  })
+      return person
+    })
+    .catch(err => {
+      logger.error(err)
+      return {
+        nomsNumber,
+        firstName: '<first name>',
+        lastName: '<last name>',
+      } as PersonSearchResult
+    })
 
 export const getPerson = async (
   nomsNumber: string,

--- a/server/routes/handlers/recallList.test.ts
+++ b/server/routes/handlers/recallList.test.ts
@@ -46,13 +46,9 @@ describe('recallList', () => {
   ]
 
   beforeEach(() => {
-    fakeManageRecallsApi.get('/recalls').reply(200, listOfRecalls)
     req = mockGetRequest({})
     const { res } = mockResponseWithAuthenticatedUser(userToken.access_token)
     resp = res
-  })
-
-  it('should make recalls with person details available to render', async () => {
     fakeManageRecallsApi
       .post('/search')
       .times(listOfRecalls.length)
@@ -62,6 +58,10 @@ describe('recallList', () => {
           lastName: 'Badger',
         },
       ])
+  })
+
+  it('should make recalls with person details available to render', async () => {
+    fakeManageRecallsApi.get('/recalls').reply(200, listOfRecalls)
     await recallList(req, resp)
     expect(resp.locals.results.toDo).toEqual([
       {
@@ -129,12 +129,12 @@ describe('recallList', () => {
   })
 
   it('should make a list of failed recall requests available to render', async () => {
-    fakeManageRecallsApi.post('/search').times(recalls.length).reply(404)
+    fakeManageRecallsApi.get('/recalls').times(recalls.length).reply(404)
     await recallList(req, resp)
     expect(resp.locals.errors).toEqual([
       {
         name: 'fetchError',
-        text: '5 recalls could not be retrieved',
+        text: 'Recalls could not be retrieved',
       },
     ])
   })

--- a/server/routes/handlers/recallList.ts
+++ b/server/routes/handlers/recallList.ts
@@ -5,57 +5,71 @@ import { getRecallList } from '../../clients/manageRecallsApi/manageRecallsApiCl
 import { RecallResult } from '../../@types'
 import { RecallResponse } from '../../@types/manage-recalls-api/models/RecallResponse'
 import { getPerson } from './helpers/personCache'
+import logger from '../../../logger'
 import { sortListByDateField, sortToDoList } from './helpers/dates'
 
 export const recallList = async (req: Request, res: Response): Promise<Response | void> => {
-  const appInsightsClient = buildAppInsightsClient()
-  const { token } = res.locals.user
-  const start = performance.now()
-  const recalls = await getRecallList(token)
-  appInsightsClient?.trackMetric({ name: 'getRecallList', value: Math.round(performance.now() - start) })
-  const recallsWithNomsNumbers = recalls.filter(recall => Boolean(recall.nomsNumber))
-  const successful = [] as RecallResult[]
-  const failed = [] as string[]
-  if (recallsWithNomsNumbers.length) {
-    const start2 = performance.now()
-    const results = await Promise.allSettled(
-      recallsWithNomsNumbers.map(recall =>
-        getPerson(recall.nomsNumber, token).then(
-          person =>
-            <RecallResult>{
-              recall,
-              person,
-            }
+  try {
+    const appInsightsClient = buildAppInsightsClient()
+    const { token } = res.locals.user
+    const start = performance.now()
+    const recalls = await getRecallList(token)
+    appInsightsClient?.trackMetric({ name: 'getRecallList', value: Math.round(performance.now() - start) })
+    const recallsWithNomsNumbers = recalls.filter(recall => Boolean(recall.nomsNumber))
+    const successful = [] as RecallResult[]
+    const failed = [] as string[]
+    if (recallsWithNomsNumbers.length) {
+      const start2 = performance.now()
+      const results = await Promise.allSettled(
+        recallsWithNomsNumbers.map(recall =>
+          getPerson(recall.nomsNumber, token).then(
+            person =>
+              <RecallResult>{
+                recall,
+                person,
+              }
+          )
         )
       )
+      appInsightsClient?.trackMetric({
+        name: 'searchByNomsNumber_total',
+        value: Math.round(performance.now() - start2),
+      })
+      appInsightsClient?.trackMetric({ name: 'searchByNomsNumber_call_count', value: recallsWithNomsNumbers.length })
+      results.forEach((result, idx) => {
+        if (result.status === 'fulfilled') {
+          successful.push(result.value)
+        } else {
+          failed.push(recalls[idx].nomsNumber)
+        }
+      })
+    }
+    const toDoList = successful.filter(
+      recallResult => recallResult.recall.status !== RecallResponse.status.DOSSIER_ISSUED
     )
-    appInsightsClient?.trackMetric({ name: 'searchByNomsNumber_total', value: Math.round(performance.now() - start2) })
-    appInsightsClient?.trackMetric({ name: 'searchByNomsNumber_call_count', value: recallsWithNomsNumbers.length })
-    results.forEach((result, idx) => {
-      if (result.status === 'fulfilled') {
-        successful.push(result.value)
-      } else {
-        failed.push(recalls[idx].nomsNumber)
-      }
-    })
-  }
-  const toDoList = successful.filter(
-    recallResult => recallResult.recall.status !== RecallResponse.status.DOSSIER_ISSUED
-  )
-  const completed = successful.filter(
-    recallResult => recallResult.recall.status === RecallResponse.status.DOSSIER_ISSUED
-  )
-  res.locals.results = {
-    toDo: sortToDoList(toDoList),
-    completed: sortListByDateField({ list: completed, dateKey: 'recall.dossierEmailSentDate', newestFirst: true }),
-  }
-  if (failed.length) {
+    const completed = successful.filter(
+      recallResult => recallResult.recall.status === RecallResponse.status.DOSSIER_ISSUED
+    )
+    res.locals.results = {
+      toDo: sortToDoList(toDoList),
+      completed: sortListByDateField({ list: completed, dateKey: 'recall.dossierEmailSentDate', newestFirst: true }),
+    }
+    if (failed.length) {
+      res.locals.errors = res.locals.errors || []
+      res.locals.errors.push({
+        name: 'fetchError',
+        text: `${failed.length} recalls could not be retrieved`,
+      })
+    }
+  } catch (err) {
+    logger.error(err)
     res.locals.errors = res.locals.errors || []
     res.locals.errors.push({
       name: 'fetchError',
-      text: `${failed.length} recalls could not be retrieved`,
+      text: 'Recalls could not be retrieved',
     })
+  } finally {
+    res.locals.isTodoPage = true
+    res.render('pages/recallList')
   }
-  res.locals.isTodoPage = true
-  res.render('pages/recallList')
 }

--- a/server/routes/handlers/recallList.ts
+++ b/server/routes/handlers/recallList.ts
@@ -20,12 +20,13 @@ export const recallList = async (req: Request, res: Response): Promise<Response 
     const start2 = performance.now()
     const results = await Promise.allSettled(
       recallsWithNomsNumbers.map(recall =>
-        getPerson(recall.nomsNumber, token).then(person => {
-          return <RecallResult>{
-            recall,
-            person,
-          }
-        })
+        getPerson(recall.nomsNumber, token).then(
+          person =>
+            <RecallResult>{
+              recall,
+              person,
+            }
+        )
       )
     )
     appInsightsClient?.trackMetric({ name: 'searchByNomsNumber_total', value: Math.round(performance.now() - start2) })


### PR DESCRIPTION
- use existing redis cache to protect against timeouts from person search API (via manage-recalls-api)
- if cache empty and API times out, render page without person details