### PR TITLE
Google analytics - send site speed data for all page loads

### DIFF
--- a/server/views/partials/analytics.njk
+++ b/server/views/partials/analytics.njk
@@ -7,7 +7,8 @@
   gtag('js', new Date());
   gtag('config', '{{ googleAnalyticsId }}', {
     page_location: document.location.href.replace(/\/persons\/[^\/]+\//, '/persons/[nomsNumber]/'),
-    {% if recall %}recallId: "{{ recall.recallId }}"{% endif %}
+    site_speed_sample_rate : 100,
+  {% if recall %}recallId: "{{ recall.recallId }}"{% endif %}
   });
   function sendToGoogleAnalytics({name, delta, id}) {
     gtag('event', name, {


### PR DESCRIPTION
Default is 1%, increase to 100%