### PR TITLE
Only set the SENTRY_DSN in pre-prod and prod

### DIFF
--- a/helm_deploy/manage-recalls-ui/values.yaml
+++ b/helm_deploy/manage-recalls-ui/values.yaml
@@ -32,7 +32,6 @@ generic-service:
     NODE_ENV: "production"
     REDIS_TLS_ENABLED: "true"
     TOKEN_VERIFICATION_ENABLED: "true"
-    SENTRY_DSN: https://4eb36239d29c4114b9d90b810063261c@o345774.ingest.sentry.io/5939012
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,7 +15,6 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     MANAGE_RECALLS_API_URL: "https://manage-recalls-api-dev.hmpps.service.justice.gov.uk"
-    SENTRY_DSN: "DO_NOT_TRACK"
     SENTRY_ENVIRONMENT: "DEV"
     ENVIRONMENT: "DEVELOPMENT"
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,7 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     MANAGE_RECALLS_API_URL: "https://manage-recalls-api-preprod.hmpps.service.justice.gov.uk"
+    SENTRY_DSN: https://4eb36239d29c4114b9d90b810063261c@o345774.ingest.sentry.io/5939012
     SENTRY_ENVIRONMENT: "PRE-PROD"
     ENVIRONMENT: "PRE-PRODUCTION"
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,6 +15,7 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     MANAGE_RECALLS_API_URL: "https://manage-recalls-api.hmpps.service.justice.gov.uk"
+    SENTRY_DSN: https://4eb36239d29c4114b9d90b810063261c@o345774.ingest.sentry.io/5939012
     SENTRY_ENVIRONMENT: "PROD"
     ENVIRONMENT: "PRODUCTION"
 


### PR DESCRIPTION
The app crashes out with an invalid DSN, but starts up fine if none is
present.