### PR TITLE
PUD-981: Configure the ingress to use the error pages app

### DIFF
--- a/helm_deploy/manage-recalls-ui/values.yaml
+++ b/helm_deploy/manage-recalls-ui/values.yaml
@@ -13,6 +13,8 @@ generic-service:
     enabled: true
     host: app-hostname.local    # override per environment
     tlsSecretName: manage-recalls-ui-cert
+    # which cluster are we on: live-1 is blue, live is green
+    contextColour: blue
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -8,7 +8,7 @@ generic-service:
     host: manage-recalls-dev.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-dev-cert
     annotations:
-      nginx.ingress.kubernetes.io/custom-http-errors: "500,501,502,503,504"
+      nginx.ingress.kubernetes.io/custom-http-errors: "501,502,503,504"
       nginx.ingress.kubernetes.io/default-backend: manage-recalls-error-pages
 
   env:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,6 +9,9 @@ generic-service:
     tlsSecretName: ppud-replacement-dev-cert
     # which cluster are we on: live-1 is blue, live is green
     contextColour: blue
+    annotations:
+      nginx.ingress.kubernetes.io/custom-http-errors: "500,501,502,503,504"
+      nginx.ingress.kubernetes.io/default-backend: manage-recalls-error-pages
 
   env:
     INGRESS_URL: "https://manage-recalls-dev.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,8 +7,6 @@ generic-service:
   ingress:
     host: manage-recalls-dev.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-dev-cert
-    # which cluster are we on: live-1 is blue, live is green
-    contextColour: blue
     annotations:
       nginx.ingress.kubernetes.io/custom-http-errors: "500,501,502,503,504"
       nginx.ingress.kubernetes.io/default-backend: manage-recalls-error-pages

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,8 +7,6 @@ generic-service:
   ingress:
     host: manage-recalls-preprod.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-preprod-cert
-    # which cluster are we on: live-1 is blue, live is green
-    contextColour: blue
 
   env:
     INGRESS_URL: "https://manage-recalls-preprod.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,8 +7,6 @@ generic-service:
   ingress:
     host: manage-recalls.hmpps.service.justice.gov.uk
     tlsSecretName: ppud-replacement-prod-cert
-    # which cluster are we on: live-1 is blue, live is green
-    contextColour: blue
 
   env:
     INGRESS_URL: "https://manage-recalls.hmpps.service.justice.gov.uk"


### PR DESCRIPTION
This sets the dev ingress to forward 5xx errors to our new custom error
pages application.