### PR TITLE
Update the prometheus-alerts helm chart

### DIFF
--- a/helm_deploy/manage-recalls-ui/Chart.yaml
+++ b/helm_deploy/manage-recalls-ui/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: 1.1.2
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.2.5
+    version: 0.2.8
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
This fixes some issues with the grafana dashboards not loading

ref PUD-1129