### PR TITLE
PUD-1411: Remove metrics from public visibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ COPY --from=build --chown=appuser:appgroup \
 ARG BUILD_NUMBER
 ENV SENTRY_RELEASE ${BUILD_NUMBER:-1_0_0}
 
-EXPOSE 3000
+EXPOSE 3000 3001
 ENV NODE_ENV='production'
 USER 2000
 

--- a/docs/running-app.md
+++ b/docs/running-app.md
@@ -1,18 +1,19 @@
-
-
 # Running the app
 
 The easiest way to run ui and api is to use
 
 `./start-local-services.sh`
 
-script in *manage-recall-e2e-tests* project (https://github.com/ministryofjustice/manage-recalls-e2e-tests)
+script in _manage-recall-e2e-tests_ project (https://github.com/ministryofjustice/manage-recalls-e2e-tests)
 
 Either way check that this has succeeded e.g. via login locally (`http://localhost:3000/`)
-with `PPUD_USER` / `password123456`.  
+with `PPUD_USER` / `password123456`.
 This user has the `MANAGE_RECALLS` role that allows access to the service.
 
+You can also check that the prometheus metrics are being served correctly on `http://localhost:3001/metrics`
+
 ### Rerunning the ui
+
 In order to restart the ui during development changes, kill the ui by running
 
 `npm run kill`
@@ -22,6 +23,7 @@ And rerun ui with
 ` npm run start:e2e`
 
 ### Old way to run the app
+
 The old way was to run the app using docker compose to create the service and all dependencies.
 This method is no longer the best due to limited functionality of fake api. Will keep it here till future changes.
 It starts the latest published docker container for hmpps-auth and redis, a fake manage-recalls-api (wiremock) and a local build of the manage-recalls-ui.
@@ -42,6 +44,7 @@ npm run start:dev
 ```
 
 #### Debugging in Chrome Developer Tools
+
 1. open the app in Chrome browser
 2. open devtools (CMD + Option + I)
 3. click the green cube at top left of devtools, to open the Node.js debugger
@@ -52,24 +55,25 @@ npm run start:dev
 8. use the debugger tools to play, step over or step into
 
 #### Debugging in IntelliJ IDEA
+
 IDEA supports debugging of the typescript source via attaching to a running node process
 as long as e.g. the `--inspect` flag has been passed to node.
 This is the case for both `npm run start:dev` or `npm run start:e2e` - as the latter
 calls the former which includes it.
 
-With the app started locally as above you can attach the debugger by starting an 
-`Attach to Node.js/Chrome` run configuration in debug mode.  Breakpoints added in
+With the app started locally as above you can attach the debugger by starting an
+`Attach to Node.js/Chrome` run configuration in debug mode. Breakpoints added in
 e.g. `*.ts` files should then become active and operate once code to execute them
 has been re-executed from the UI e.g. in Chrome.
 
 When the debugger has attached the node process will log:
+
 ```
 [Node] Debugger attached.
 ```
 
-
 #### Updating (fake-manage-recalls-api) wiremock responses
 
 If you need to update the wiremock (fake-manage-recalls-api) mappings you can use the `scripts/restart-fake-manage-recalls-api.sh`
-to stop and start the wiremock server.  Or you can use the `manual-stub.test.ts` test to prime the running wiremock server
+to stop and start the wiremock server. Or you can use the `manual-stub.test.ts` test to prime the running wiremock server
 with any additional expectation.

--- a/helm_deploy/manage-recalls-ui/Chart.yaml
+++ b/helm_deploy/manage-recalls-ui/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 
 dependencies:
   - name: generic-service
-    version: 1.1.2
+    version: 1.2.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 0.2.8

--- a/helm_deploy/manage-recalls-ui/values.yaml
+++ b/helm_deploy/manage-recalls-ui/values.yaml
@@ -32,6 +32,7 @@ generic-service:
     enabled: true
     scrapeInterval: 15s
     metricsPath: /metrics
+    metricsPort: 3001
 
   # Environment variables to load into the deployment
   env:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start:dev": "concurrently -k -p \"[{name}]\" -n \"Node,Styles\" -c \"yellow.bold,cyan.bold\" \"node -r ts-node/register/transpile-only --inspect=0.0.0.0 server.ts\" \"npm run compile-sass -- --watch\"",
     "start:e2e": "export $(cat e2e.env) && npm run start:dev",
     "start:feature": "export $(cat feature.env) && npm run build && node $NODE_OPTIONS --inspect=0.0.0.0 dist/server.js",
-    "kill": "npx kill-port 3000,9229",
+    "kill": "npx kill-port 3000,3001,9229",
     "record-build-info": "node ./bin/record-build-info",
     "swagger-to-ts": "node ./scripts/swagger-to-ts.js",
     "lint": "eslint . --cache --max-warnings 0",

--- a/server.ts
+++ b/server.ts
@@ -8,9 +8,13 @@ import { initialiseAppInsights, buildAppInsightsClient } from './server/utils/az
 initialiseAppInsights()
 buildAppInsightsClient()
 
-import app from './server/index'
+import { app, metricsApp } from './server/index'
 import logger from './logger'
 
 app.listen(app.get('port'), () => {
   logger.info(`Server listening on port ${app.get('port')}`)
+})
+
+metricsApp.listen(metricsApp.get('port'), () => {
+  logger.info(`Metrics server listening on port ${metricsApp.get('port')}`)
 })

--- a/server/app.ts
+++ b/server/app.ts
@@ -15,7 +15,6 @@ import session from 'express-session'
 import connectRedis from 'connect-redis'
 import { randomBytes } from 'crypto'
 
-import promBundle from 'express-prom-bundle'
 import auth from './authentication/auth'
 import indexRoutes from './routes'
 import healthcheck from './services/healthCheck'

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
-import { createApp, createMetricsApp } from './app'
+import createApp from './app'
+import { createMetricsApp } from './metricsApp'
 import { HmppsAuthClient } from './data/hmppsAuthClient'
 import TokenStore from './data/tokenStore'
 import UserService from './services/userService'

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,4 @@
-import createApp from './app'
+import { createApp, createMetricsApp } from './app'
 import { HmppsAuthClient } from './data/hmppsAuthClient'
 import TokenStore from './data/tokenStore'
 import UserService from './services/userService'
@@ -7,5 +7,6 @@ const hmppsAuthClient = new HmppsAuthClient(new TokenStore())
 const userService = new UserService(hmppsAuthClient)
 
 const app = createApp(userService)
+const metricsApp = createMetricsApp()
 
-export default app
+export { app, metricsApp }

--- a/server/metricsApp.ts
+++ b/server/metricsApp.ts
@@ -1,0 +1,26 @@
+import express from 'express'
+import promBundle from 'express-prom-bundle'
+
+const metricsMiddleware = promBundle({
+  includeMethod: true,
+  includePath: true,
+  autoregister: false,
+  normalizePath: [['^/assets/.+$', '/assets/#assetPath']],
+})
+
+function metricsPort(): number {
+  let port = 3000
+  if (process.env.PORT != null) {
+    port = Number(process.env.PORT)
+  }
+  return port + 1
+}
+
+function createMetricsApp(): express.Application {
+  const metricsApp = express()
+  metricsApp.use(metricsMiddleware.metricsMiddleware)
+  metricsApp.set('port', metricsPort())
+  return metricsApp
+}
+
+export { metricsMiddleware, createMetricsApp }


### PR DESCRIPTION
This change keeps the application being served on port 3000, but moves
the prometheus metrics to port 3001. This will mean that the metrics are
no longer publicly accessible, so should keep security happy.