### PR TITLE
Update the generic-service helm chart

### DIFF
--- a/helm_deploy/manage-recalls-ui/Chart.yaml
+++ b/helm_deploy/manage-recalls-ui/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 
 dependencies:
   - name: generic-service
-    version: 1.2.0
+    version: 1.2.1
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 0.2.8


### PR DESCRIPTION
This fixes the issue where the prometheus metrics were no longer being
scraped as they were no longer on the `http` port.