### PR TITLE
Fix the `/health` endpoint

### DIFF
--- a/dev-local.env
+++ b/dev-local.env
@@ -5,6 +5,7 @@ INGRESS_URL=http://localhost:3000
 HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth
 HMPPS_AUTH_URL=http://localhost:9090/auth
 MANAGE_RECALLS_API_URL=http://localhost:9091
+MANAGE_RECALLS_API_HEALTHCHECK_URL=http://localhost:9097
 API_CLIENT_ID=ppud-ui-client
 API_CLIENT_SECRET=clientsecret
 SYSTEM_CLIENT_ID=system-client-id

--- a/e2e.env
+++ b/e2e.env
@@ -5,6 +5,7 @@ INGRESS_URL=http://localhost:3000
 HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth
 HMPPS_AUTH_URL=http://localhost:9090/auth
 MANAGE_RECALLS_API_URL=http://localhost:8080
+MANAGE_RECALLS_API_HEALTHCHECK_URL=http://localhost:8081
 OS_PLACES_API_URL=http://localhost:9096/search/places/v1
 OS_PLACES_API_KEY=key
 API_CLIENT_ID=ppud-ui-client

--- a/feature.env
+++ b/feature.env
@@ -2,6 +2,7 @@ PORT=3000
 HMPPS_AUTH_URL=http://localhost:9091/auth
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 MANAGE_RECALLS_API_URL=http://localhost:9091
+MANAGE_RECALLS_API_HEALTHCHECK_URL=http://localhost:9097
 OS_PLACES_API_URL=http://localhost:9091/search/places/v1
 NODE_ENV=development
 API_CLIENT_ID=ppud-ui-client

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     MANAGE_RECALLS_API_URL: "https://manage-recalls-api-dev.hmpps.service.justice.gov.uk"
+    MANAGE_RECALLS_API_HEALTHCHECK_URL: http://manage-recalls-api.manage-recalls-dev:81
     SENTRY_ENVIRONMENT: "DEV"
     ENVIRONMENT: "DEVELOPMENT"
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     MANAGE_RECALLS_API_URL: "https://manage-recalls-api-preprod.hmpps.service.justice.gov.uk"
+    MANAGE_RECALLS_API_HEALTHCHECK_URL: http://manage-recalls-api.manage-recalls-preprod:81
     SENTRY_DSN: https://4eb36239d29c4114b9d90b810063261c@o345774.ingest.sentry.io/5939012
     SENTRY_ENVIRONMENT: "PRE-PROD"
     ENVIRONMENT: "PRE-PRODUCTION"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,6 +12,7 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     MANAGE_RECALLS_API_URL: "https://manage-recalls-api.hmpps.service.justice.gov.uk"
+    MANAGE_RECALLS_API_HEALTHCHECK_URL: http://manage-recalls-api.manage-recalls-prod:81
     SENTRY_DSN: https://4eb36239d29c4114b9d90b810063261c@o345774.ingest.sentry.io/5939012
     SENTRY_ENVIRONMENT: "PROD"
     ENVIRONMENT: "PRODUCTION"

--- a/server/config.ts
+++ b/server/config.ts
@@ -60,6 +60,7 @@ const config = {
     },
     manageRecallsApi: {
       url: get('MANAGE_RECALLS_API_URL', 'http://localhost:9091', requiredInProduction),
+      healthCheckUrl: get('MANAGE_RECALLS_API_HEALTHCHECK_URL', 'http://localhost:9097', requiredInProduction),
       timeout: {
         response: Number(get('MANAGE_RECALLS_API_TIMEOUT_RESPONSE', 10000)),
         deadline: Number(get('MANAGE_RECALLS_API_TIMEOUT_DEADLINE', 10000)),

--- a/server/healthChecks/healthCheck.ts
+++ b/server/healthChecks/healthCheck.ts
@@ -57,7 +57,11 @@ function gatherCheckInfo(aggregateStatus: Record<string, unknown>, currentStatus
 
 const apiChecks = [
   service('hmppsAuth', `${config.apis.hmppsAuth.url}/health/ping`, config.apis.hmppsAuth.agent),
-  service('manageRecallsApi', `${config.apis.manageRecallsApi.url}/health/ping`, config.apis.manageRecallsApi.agent),
+  service(
+    'manageRecallsApi',
+    `${config.apis.manageRecallsApi.healthCheckUrl}/health/ping`,
+    config.apis.manageRecallsApi.agent
+  ),
   ...(config.apis.tokenVerification.enabled
     ? [
         service(


### PR DESCRIPTION
Now that `/health/ping` is no longer public on the API application we
need to connect to the internal kubernetes service.

Question: Do we do any client-side requests to the API? If not, we
should probably use the kubernetes service (port 80) to save the whole
internet round trip on each request to the API...