### PR TITLE
PUD-1526 - email upload refactor

### DIFF
--- a/server/controllers/assess/validators/validateDecision.test.ts
+++ b/server/controllers/assess/validators/validateDecision.test.ts
@@ -112,13 +112,17 @@ describe('validateDecision', () => {
       confirmedRecallType: 'FIXED',
       confirmedRecallTypeDetailFixed: 'reason 1; reason 2',
     }
-    const { errors, valuesToSave } = validateDecision({
+    const { errors, unsavedValues, valuesToSave } = validateDecision({
       requestBody,
       emailFileSelected: false,
       uploadFailed: false,
       invalidFileFormat: false,
     })
     expect(valuesToSave).toBeUndefined()
+    expect(unsavedValues).toEqual({
+      confirmedRecallType: 'FIXED',
+      confirmedRecallTypeDetailFixed: 'reason 1; reason 2',
+    })
     expect(errors).toEqual([
       {
         href: '#confirmedRecallTypeEmailFileName',

--- a/server/controllers/assess/validators/validateDecision.ts
+++ b/server/controllers/assess/validators/validateDecision.ts
@@ -10,7 +10,6 @@ export const validateDecision = ({
   invalidFileFormat,
 }: EmailUploadValidatorArgs): ReqValidatorReturn<ConfirmedRecallTypeRequest> => {
   let errors
-  let unsavedValues
   let valuesToSave
 
   const {
@@ -78,11 +77,11 @@ export const validateDecision = ({
         })
       )
     }
-    unsavedValues = {
-      confirmedRecallType,
-      confirmedRecallTypeDetailFixed,
-      confirmedRecallTypeDetailStandard,
-    }
+  }
+  const unsavedValues = {
+    confirmedRecallType,
+    confirmedRecallTypeDetailFixed,
+    confirmedRecallTypeDetailStandard,
   }
   if (!errors) {
     const detail = isFixed ? confirmedRecallTypeDetailFixed : confirmedRecallTypeDetailStandard

--- a/server/controllers/assess/validators/validateRecallNotificationEmail.test.ts
+++ b/server/controllers/assess/validators/validateRecallNotificationEmail.test.ts
@@ -88,7 +88,7 @@ describe('validateEmail', () => {
   })
 
   it("returns an error if an email wasn't uploaded", () => {
-    const { errors, valuesToSave } = validateRecallNotificationEmail({
+    const { errors, unsavedValues, valuesToSave } = validateRecallNotificationEmail({
       requestBody,
       fileName: 'test.msg',
       emailFileSelected: false,
@@ -97,6 +97,17 @@ describe('validateEmail', () => {
       actionedByUserId,
     })
     expect(valuesToSave).toBeUndefined()
+    expect(unsavedValues).toEqual({
+      confirmRecallNotificationEmailSent: 'YES',
+      recallNotificationEmailFileName: 'test.msg',
+      recallNotificationEmailSentDateTimeParts: {
+        day: '04',
+        hour: '14',
+        minute: '47',
+        month: '09',
+        year: '2021',
+      },
+    })
     expect(errors).toEqual([
       {
         href: '#recallNotificationEmailFileName',

--- a/server/controllers/assess/validators/validateRecallNotificationEmail.ts
+++ b/server/controllers/assess/validators/validateRecallNotificationEmail.ts
@@ -13,7 +13,6 @@ export const validateRecallNotificationEmail = ({
   actionedByUserId,
 }: EmailUploadValidatorArgs): ReqValidatorReturn<UpdateRecallRequest> => {
   let errors
-  let unsavedValues
   let valuesToSave
 
   const { confirmRecallNotificationEmailSent } = requestBody
@@ -80,11 +79,11 @@ export const validateRecallNotificationEmail = ({
         })
       )
     }
-    unsavedValues = {
-      recallNotificationEmailFileName: fileName,
-      confirmRecallNotificationEmailSent,
-      recallNotificationEmailSentDateTimeParts,
-    }
+  }
+  const unsavedValues = {
+    recallNotificationEmailFileName: fileName,
+    confirmRecallNotificationEmailSent,
+    recallNotificationEmailSentDateTimeParts,
   }
   if (!errors) {
     valuesToSave = { recallNotificationEmailSentDateTime, assessedByUserId: actionedByUserId } as UpdateRecallRequest

--- a/server/controllers/book/validators/validateRecallRequestReceived.test.ts
+++ b/server/controllers/book/validators/validateRecallRequestReceived.test.ts
@@ -187,7 +187,7 @@ describe('validateRecallRequestReceived', () => {
     expect(errors[0].text).toEqual('The time you received the recall email must be a real time')
   })
 
-  it("returns an error if an email wasn't uploaded", () => {
+  it("returns an error and unsaved values if an email wasn't uploaded", () => {
     const requestBody = {
       recallEmailReceivedDateTimeDay: '12',
       recallEmailReceivedDateTimeMonth: '09',
@@ -195,7 +195,7 @@ describe('validateRecallRequestReceived', () => {
       recallEmailReceivedDateTimeHour: '22',
       recallEmailReceivedDateTimeMinute: '14',
     }
-    const { errors, valuesToSave } = validateRecallRequestReceived({
+    const { errors, unsavedValues, valuesToSave } = validateRecallRequestReceived({
       requestBody,
       fileName: 'test.eml',
       emailFileSelected: false,
@@ -203,6 +203,15 @@ describe('validateRecallRequestReceived', () => {
       invalidFileFormat: false,
     })
     expect(valuesToSave).toBeUndefined()
+    expect(unsavedValues).toEqual({
+      recallEmailReceivedDateTimeParts: {
+        day: '12',
+        hour: '22',
+        minute: '14',
+        month: '09',
+        year: '2021',
+      },
+    })
     expect(errors).toEqual([
       {
         href: '#recallRequestEmailFileName',

--- a/server/controllers/book/validators/validateRecallRequestReceived.ts
+++ b/server/controllers/book/validators/validateRecallRequestReceived.ts
@@ -11,7 +11,6 @@ export const validateRecallRequestReceived = ({
   invalidFileFormat,
 }: EmailUploadValidatorArgs): ReqValidatorReturn<UpdateRecallRequest> => {
   let errors
-  let unsavedValues
   let valuesToSave
   const recallEmailReceivedDateTimeParts = {
     year: requestBody.recallEmailReceivedDateTimeYear,
@@ -43,7 +42,7 @@ export const validateRecallRequestReceived = ({
       )
     }
 
-    if (!emailFileSelected && !existingUpload) {
+    if (!uploadFailed && !emailFileSelected && !existingUpload) {
       errors.push(
         makeErrorObject({
           id: 'recallRequestEmailFileName',
@@ -67,9 +66,9 @@ export const validateRecallRequestReceived = ({
         })
       )
     }
-    unsavedValues = {
-      recallEmailReceivedDateTimeParts,
-    }
+  }
+  const unsavedValues = {
+    recallEmailReceivedDateTimeParts,
   }
   if (!errors) {
     valuesToSave = { recallEmailReceivedDateTime } as UpdateRecallRequest

--- a/server/controllers/documents/upload/helpers/processUpload.ts
+++ b/server/controllers/documents/upload/helpers/processUpload.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from 'express'
+import logger from '../../../../../logger'
+import { uploadStorageField } from './uploadStorage'
+
+export const processUpload = (
+  emailFieldName: string,
+  req: Request,
+  res: Response
+): Promise<{ request: Request; uploadFailed: boolean }> => {
+  return new Promise(resolve => {
+    const processFn = uploadStorageField(emailFieldName)
+    processFn(req, res, async err => {
+      if (err) {
+        logger.error(err)
+      }
+      return resolve({
+        request: req,
+        uploadFailed: Boolean(err),
+      })
+    })
+  })
+}

--- a/server/controllers/documents/upload/uploadEmailFormHandler.ts
+++ b/server/controllers/documents/upload/uploadEmailFormHandler.ts
@@ -1,106 +1,103 @@
 import { Request, Response } from 'express'
 import { updateRecall, uploadRecallDocument } from '../../../clients/manageRecallsApiClient'
-import logger from '../../../../logger'
-import { uploadStorageField } from './helpers/uploadStorage'
-
 import { UploadDocumentRequest } from '../../../@types/manage-recalls-api/models/UploadDocumentRequest'
 import { NamedFormError, ReqEmailUploadValidatorFn, SaveToApiFn } from '../../../@types'
 import { allowedEmailFileExtensions } from './helpers/allowedUploadExtensions'
-import { errorMsgEmailUpload, makeErrorObject } from '../../utils/errorMessages'
+import { errorMsgEmailUpload, makeErrorObject, saveErrorWithDetails } from '../../utils/errorMessages'
 import { makeUrl, makeUrlToFromPage } from '../../utils/makeUrl'
-
-interface Args {
-  emailFieldName: string
-  validator: ReqEmailUploadValidatorFn
-  documentCategory: UploadDocumentRequest.category
-  saveToApiFn?: SaveToApiFn
-}
+import { processUpload } from './helpers/processUpload'
 
 export const uploadEmailFormHandler =
-  ({ emailFieldName, validator, documentCategory, saveToApiFn }: Args) =>
+  ({
+    emailFieldName,
+    validator,
+    documentCategory,
+    saveToApiFn,
+  }: {
+    emailFieldName: string
+    validator: ReqEmailUploadValidatorFn
+    documentCategory: UploadDocumentRequest.category
+    saveToApiFn?: SaveToApiFn
+  }) =>
   async (req: Request, res: Response): Promise<void> => {
-    const processUpload = uploadStorageField(emailFieldName)
     const { recallId } = req.params
     const { user, urlInfo } = res.locals
-    let saveError = [
-      makeErrorObject({
-        id: emailFieldName,
-        text: errorMsgEmailUpload.uploadFailed,
-      }),
-    ]
-    let saveToApiSuccessful = false
-    processUpload(req, res, async err => {
+    let emailSavedToApi = false
+    const { request, uploadFailed } = await processUpload(emailFieldName, req, res)
+    const { file } = request
+    const emailFileSelected = Boolean(file)
+    const invalidFileFormat = emailFileSelected
+      ? !allowedEmailFileExtensions.some(ext => file.originalname.endsWith(ext.extension))
+      : false
+    const { errors, valuesToSave, unsavedValues, redirectToPage } = validator({
+      requestBody: request.body,
+      fileName: file?.originalname,
+      emailFileSelected,
+      uploadFailed,
+      invalidFileFormat,
+      actionedByUserId: user.uuid,
+    })
+    let errorList = errors
+    const uploadHasErrors =
+      errorList && errorList.find((uploadError: NamedFormError) => uploadError.name === emailFieldName)
+    const shouldSaveEmailToApi = !uploadHasErrors && emailFileSelected && !uploadFailed
+
+    // save email to api
+    if (shouldSaveEmailToApi) {
       try {
-        const uploadFailed = Boolean(err)
-        const { file } = req
-        const emailFileSelected = Boolean(file)
-        const invalidFileFormat = emailFileSelected
-          ? !allowedEmailFileExtensions.some(ext => file.originalname.endsWith(ext.extension))
-          : false
-        const { errors, valuesToSave, unsavedValues, redirectToPage } = validator({
-          requestBody: req.body,
-          fileName: file?.originalname,
-          emailFileSelected,
-          uploadFailed,
-          invalidFileFormat,
-          actionedByUserId: user.uuid,
-        })
-        const uploadHasErrors =
-          errors && errors.find((uploadError: NamedFormError) => uploadError.name === emailFieldName)
-        const shouldSaveToApi = !uploadHasErrors && emailFileSelected && !uploadFailed
-        if (shouldSaveToApi) {
-          try {
-            const response = await uploadRecallDocument(
-              recallId,
-              {
-                fileName: file.originalname,
-                fileContent: file.buffer.toString('base64'),
-                category: documentCategory,
-              },
-              user.token
-            )
-            if (response.documentId) {
-              saveToApiSuccessful = true
-            }
-          } catch (e) {
-            saveToApiSuccessful = false
-            if (e.data?.message === 'VirusFoundException') {
-              saveError = [
-                makeErrorObject({
-                  id: emailFieldName,
-                  text: `${file.originalname} contains a virus`,
-                }),
-              ]
-            }
-          }
-        }
-        if (errors || (shouldSaveToApi && !saveToApiSuccessful)) {
-          req.session.errors = errors || saveError
-          req.session.unsavedValues = unsavedValues
-          return res.redirect(303, req.originalUrl)
-        }
-        if (valuesToSave) {
-          if (saveToApiFn) {
-            await saveToApiFn({ recallId, valuesToSave, user })
-          } else {
-            await updateRecall(recallId, valuesToSave, user.token)
-          }
-        }
-        return res.redirect(
-          303,
-          urlInfo.fromPage ? makeUrlToFromPage(urlInfo.fromPage, urlInfo) : makeUrl(redirectToPage, urlInfo)
+        const response = await uploadRecallDocument(
+          recallId,
+          {
+            fileName: file.originalname,
+            fileContent: file.buffer.toString('base64'),
+            category: documentCategory,
+          },
+          user.token
         )
+        if (response.documentId) {
+          emailSavedToApi = true
+        }
       } catch (e) {
-        logger.error(e)
-        req.session.errors = !saveToApiSuccessful
-          ? saveError
-          : [
-              {
-                name: 'saveError',
-                text: 'An error occurred saving the completed assessment',
-              },
-            ]
+        emailSavedToApi = false
+        if (e.data?.message === 'VirusFoundException') {
+          // add to any existing validation errors
+          errorList = [
+            ...(errors || []),
+            makeErrorObject({
+              id: emailFieldName,
+              text: `${file.originalname} contains a virus`,
+            }),
+          ]
+        }
+      }
+    }
+    // either saving email to api failed, or other field(s) had validation errors
+    if (errorList || (shouldSaveEmailToApi && !emailSavedToApi)) {
+      req.session.errors = errorList || [
+        makeErrorObject({
+          id: emailFieldName,
+          text: errorMsgEmailUpload.uploadFailed,
+        }),
+      ]
+      req.session.unsavedValues = unsavedValues
+      return res.redirect(303, req.originalUrl)
+    }
+    // form field values other than the uploaded email
+    if (valuesToSave) {
+      try {
+        if (saveToApiFn) {
+          await saveToApiFn({ recallId, valuesToSave, user })
+        } else {
+          await updateRecall(recallId, valuesToSave, user.token)
+        }
+      } catch (e) {
+        req.session.unsavedValues = unsavedValues
+        req.session.errors = saveErrorWithDetails({ err: e, res })
         res.redirect(303, req.originalUrl)
       }
-    })
+    }
+    return res.redirect(
+      303,
+      urlInfo.fromPage ? makeUrlToFromPage(urlInfo.fromPage, urlInfo) : makeUrl(redirectToPage, urlInfo)
+    )
   }

--- a/server/controllers/dossier/validators/validateDossierEmail.test.ts
+++ b/server/controllers/dossier/validators/validateDossierEmail.test.ts
@@ -88,7 +88,7 @@ describe('validateDossierEmail', () => {
   })
 
   it("returns an error if an email wasn't uploaded", () => {
-    const { errors, valuesToSave } = validateDossierEmail({
+    const { errors, unsavedValues, valuesToSave } = validateDossierEmail({
       requestBody,
       fileName: 'test.msg',
       emailFileSelected: false,
@@ -97,6 +97,15 @@ describe('validateDossierEmail', () => {
       actionedByUserId,
     })
     expect(valuesToSave).toBeUndefined()
+    expect(unsavedValues).toEqual({
+      confirmDossierEmailSent: 'YES',
+      dossierEmailFileName: 'test.msg',
+      dossierEmailSentDateParts: {
+        day: '04',
+        month: '09',
+        year: '2021',
+      },
+    })
     expect(errors).toEqual([
       {
         href: '#dossierEmailFileName',

--- a/server/controllers/dossier/validators/validateDossierEmail.ts
+++ b/server/controllers/dossier/validators/validateDossierEmail.ts
@@ -14,7 +14,6 @@ export const validateDossierEmail = ({
   actionedByUserId,
 }: EmailUploadValidatorArgs): ReqValidatorReturn<UpdateRecallRequest> => {
   let errors
-  let unsavedValues
   let valuesToSave
 
   const { confirmDossierEmailSent } = requestBody
@@ -74,11 +73,11 @@ export const validateDossierEmail = ({
         })
       )
     }
-    unsavedValues = {
-      dossierEmailFileName: fileName,
-      confirmDossierEmailSent,
-      dossierEmailSentDateParts,
-    }
+  }
+  const unsavedValues = {
+    dossierEmailFileName: fileName,
+    confirmDossierEmailSent,
+    dossierEmailSentDateParts,
   }
   if (!errors) {
     valuesToSave = { dossierEmailSentDate: dossierEmailSentDate as string, dossierCreatedByUserId: actionedByUserId }

--- a/server/controllers/dossier/validators/validateNsyEmail.test.ts
+++ b/server/controllers/dossier/validators/validateNsyEmail.test.ts
@@ -51,7 +51,7 @@ describe('validateNsyEmail', () => {
   })
 
   it("returns an error if an email wasn't uploaded", () => {
-    const { errors, valuesToSave } = validateNsyEmail({
+    const { errors, unsavedValues, valuesToSave } = validateNsyEmail({
       requestBody,
       fileName: 'test.msg',
       emailFileSelected: false,
@@ -59,6 +59,10 @@ describe('validateNsyEmail', () => {
       invalidFileFormat: false,
     })
     expect(valuesToSave).toBeUndefined()
+    expect(unsavedValues).toEqual({
+      confirmNsyEmailSent: 'YES',
+      nsyEmailFileName: 'test.msg',
+    })
     expect(errors).toEqual([
       {
         href: '#nsyEmailFileName',

--- a/server/controllers/dossier/validators/validateNsyEmail.ts
+++ b/server/controllers/dossier/validators/validateNsyEmail.ts
@@ -12,7 +12,6 @@ export const validateNsyEmail = ({
   invalidFileFormat,
 }: EmailUploadValidatorArgs): ReqValidatorReturn<UpdateRecallRequest> => {
   let errors
-  let unsavedValues
 
   const { confirmNsyEmailSent } = requestBody
   const existingUpload = requestBody[UploadDocumentRequest.category.NSY_REMOVE_WARRANT_EMAIL] === 'existingUpload'
@@ -50,10 +49,10 @@ export const validateNsyEmail = ({
         })
       )
     }
-    unsavedValues = {
-      nsyEmailFileName: fileName,
-      confirmNsyEmailSent,
-    }
+  }
+  const unsavedValues = {
+    nsyEmailFileName: fileName,
+    confirmNsyEmailSent,
   }
   return { errors, unsavedValues, redirectToPage: 'dossier-letter' }
 }

--- a/server/controllers/utils/errorMessages.ts
+++ b/server/controllers/utils/errorMessages.ts
@@ -165,18 +165,3 @@ export const renderErrorMessages = (
     { list: [] }
   ) as KeyedFormErrors
 }
-
-export const saveErrorWithDetails = ({ err, res }: { err: Error; res: Response }) => {
-  return [
-    {
-      name: 'saveError',
-      text:
-        res.locals.env === 'PRODUCTION'
-          ? 'An error occurred saving your changes'
-          : `Error thrown:
-                ${err?.message}
-                ${err?.stack}
-              `,
-    },
-  ]
-}

--- a/server/controllers/utils/errorMessages.ts
+++ b/server/controllers/utils/errorMessages.ts
@@ -1,3 +1,4 @@
+import { Response } from 'express'
 import { FormError, KeyedFormErrors, NamedFormError, ObjectMap, ValidationError } from '../../@types'
 import {
   allowedDocumentFileExtensions,
@@ -163,4 +164,19 @@ export const renderErrorMessages = (
     },
     { list: [] }
   ) as KeyedFormErrors
+}
+
+export const saveErrorWithDetails = ({ err, res }: { err: Error; res: Response }) => {
+  return [
+    {
+      name: 'saveError',
+      text:
+        res.locals.env === 'PRODUCTION'
+          ? 'An error occurred saving your changes'
+          : `Error thrown:
+                ${err?.message}
+                ${err?.stack}
+              `,
+    },
+  ]
 }

--- a/server/controllers/utils/errorMessages.ts
+++ b/server/controllers/utils/errorMessages.ts
@@ -1,4 +1,3 @@
-import { Response } from 'express'
 import { FormError, KeyedFormErrors, NamedFormError, ObjectMap, ValidationError } from '../../@types'
 import {
   allowedDocumentFileExtensions,

--- a/server/views/partials/notes.njk
+++ b/server/views/partials/notes.njk
@@ -49,7 +49,7 @@
     {% else %}
         <div class="govuk-summary-list__row">
             <dd class="govuk-summary-list__value" data-qa='noNotesText'>
-                No notes have been added to this recall.
+                <p class='govuk-body'>No notes have been added to this recall.</p>
             </dd>
         </div>
     {% endif %}


### PR DESCRIPTION
- improve test coverage for `uploadEmailFormHandler.ts` (check redirect URLs; improve test descriptions)
- validators for email upload forms - always return unsavedValues, even if no errors, so form input values can be redisplayed in the case when they're valid but the upload isn't ([bug #5 in PUD-1109](https://dsdmoj.atlassian.net/browse/PUD-741?focusedCommentId=202359))
- refactor `uploadEmailFormHandler.ts` - remove callback, consistent use of async/await; better variable naming & comments; simpler error handling; combine upload errors with other form validation errors

also - fix font for 'no notes' message ([bug #1 in PUD-1109](https://dsdmoj.atlassian.net/browse/PUD-741?focusedCommentId=202359)