### PR TITLE
This is a second stab at the client metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,8 @@
         "prom-client": "^14.0.1",
         "redis": "^3.1.2",
         "superagent": "^7.0.2",
+        "superagent-node-http-timings": "^1.0.1",
+        "url-value-parser": "^2.1.0",
         "web-vitals": "^2.1.3"
       },
       "devDependencies": {
@@ -21335,6 +21337,17 @@
         "node": ">=6.4.0 <13 || >=14"
       }
     },
+    "node_modules/superagent-node-http-timings": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/superagent-node-http-timings/-/superagent-node-http-timings-1.0.1.tgz",
+      "integrity": "sha512-d+iwOeDGnKrcJ8U7YMF6lXYaKMB/grpDPVbsH9YPy6vZsH8+uRT9NjxpELrn6QlH9pPDgNANiw71PxUdwSBfrQ==",
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "peerDependencies": {
+        "superagent": "*"
+      }
+    },
     "node_modules/superagent/node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -22577,9 +22590,9 @@
       }
     },
     "node_modules/url-value-parser": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.3.tgz",
-      "integrity": "sha512-FjIX+Q9lYmDM9uYIGdMYfQW0uLbWVwN2NrL2ayAI7BTOvEwzH+VoDdNquwB9h4dFAx+u6mb0ONLa3sHD5DvyvA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.1.0.tgz",
+      "integrity": "sha512-gIYPWXujdUdwd/9TGCHTf5Vvgw6lOxjE5Q/k+7WNByYyS0vW5WX0k+xuVlhvPq6gRNhzXVv/ezC+OfeAet5Kcw==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -39375,6 +39388,12 @@
         }
       }
     },
+    "superagent-node-http-timings": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/superagent-node-http-timings/-/superagent-node-http-timings-1.0.1.tgz",
+      "integrity": "sha512-d+iwOeDGnKrcJ8U7YMF6lXYaKMB/grpDPVbsH9YPy6vZsH8+uRT9NjxpELrn6QlH9pPDgNANiw71PxUdwSBfrQ==",
+      "requires": {}
+    },
     "supertest": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.2.1.tgz",
@@ -40254,9 +40273,9 @@
       }
     },
     "url-value-parser": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.3.tgz",
-      "integrity": "sha512-FjIX+Q9lYmDM9uYIGdMYfQW0uLbWVwN2NrL2ayAI7BTOvEwzH+VoDdNquwB9h4dFAx+u6mb0ONLa3sHD5DvyvA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.1.0.tgz",
+      "integrity": "sha512-gIYPWXujdUdwd/9TGCHTf5Vvgw6lOxjE5Q/k+7WNByYyS0vW5WX0k+xuVlhvPq6gRNhzXVv/ezC+OfeAet5Kcw=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,8 @@
     "prom-client": "^14.0.1",
     "redis": "^3.1.2",
     "superagent": "^7.0.2",
+    "superagent-node-http-timings": "^1.0.1",
+    "url-value-parser": "^2.1.0",
     "web-vitals": "^2.1.3"
   },
   "devDependencies": {

--- a/server/@types/superagent-node-http-timings/index.d.ts
+++ b/server/@types/superagent-node-http-timings/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'superagent-node-http-timings'

--- a/server/clients/restClient.test.ts
+++ b/server/clients/restClient.test.ts
@@ -1,0 +1,60 @@
+import RestClient, { requestHistogram, timeoutCounter } from './restClient'
+import { AgentConfig, ApiConfig } from '../config'
+
+describe('RestClient', () => {
+  let config: ApiConfig
+  let subject: RestClient
+  let responseTimeout: number
+  let deadlineTimeout: number
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  // describe('records request timings for prometheus', () => {
+  //   beforeEach(() => {
+  //     config = { url: 'https://httpbin.org', timeout: { response: 10000, deadline: 10000 }, agent: new AgentConfig }
+  //     subject = new RestClient('Test Client', config)
+  //   })
+
+  //   const requestHistogramLabelsSpy = jest.spyOn(requestHistogram, 'labels').mockReturnValue(requestHistogram)
+  //   const requestHistogramStartSpy = jest.spyOn(requestHistogram, 'observe')
+
+  //   it('on GET requests', async () => {
+  //     await subject.get({ path: '/get' })
+
+  //     expect(requestHistogramLabelsSpy).toHaveBeenCalledTimes(1)
+  //     expect(requestHistogramLabelsSpy).toHaveBeenCalledWith('httpbin.org', 'GET', '/get', '200')
+  //     expect(requestHistogramStartSpy).toHaveBeenCalledTimes(1)
+  //   })
+
+  //   // it('on POST requests', async () => {
+  //   //   await subject.post({ path: '/post' })
+
+  //   //   expect(requestHistogramLabelsSpy).toHaveBeenCalledTimes(1)
+  //   //   expect(requestHistogramLabelsSpy).toHaveBeenCalledWith('httpbin.org', 'POST', '/post', '200')
+  //   //   expect(requestHistogramStartSpy).toHaveBeenCalledTimes(1)
+  //   // })
+  // })
+
+  describe('records counts of timeout errors', () => {
+    const timeoutCounterLabelsSpy = jest.spyOn(timeoutCounter, 'labels').mockReturnValue(timeoutCounter)
+    const timeoutCounterIncSpy = jest.spyOn(timeoutCounter, 'inc')
+
+    beforeEach(() => {
+      config = { url: 'https://httpbin.org', timeout: { response: 100, deadline: 100 }, agent: new AgentConfig() }
+      subject = new RestClient('Test Client', config)
+    })
+
+    it('on GET requests', async () => {
+      try {
+        await subject.get({ path: '/delay/1' })
+      } catch {
+        // no-op
+      }
+
+      expect(timeoutCounterLabelsSpy).toHaveBeenCalledWith('httpbin.org', 'GET', '/delay/1')
+      expect(timeoutCounterIncSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/server/clients/restClient.ts
+++ b/server/clients/restClient.ts
@@ -1,6 +1,10 @@
 import superagent from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
+import promClient from 'prom-client'
+// import UrlValueParser from 'url-value-parser'
+import logNetworkTime from 'superagent-node-http-timings'
 
+import UrlValueParser from 'url-value-parser'
 import logger from '../../logger'
 import sanitiseError from '../utils/sanitisedError'
 import { ApiConfig } from '../config'
@@ -36,6 +40,25 @@ interface DeleteRequest {
   raw?: boolean
 }
 
+export const requestHistogram = new promClient.Histogram({
+  name: 'http_client_requests',
+  help: 'Timings and counts of http client requests',
+  buckets: [0.5, 0.75, 0.95, 0.99, 1],
+  labelNames: ['clientName', 'method', 'uri', 'status'],
+})
+
+export const timeoutCounter = new promClient.Counter({
+  name: 'http_client_requests_timeout',
+  help: 'Count of http client request timeouts',
+  labelNames: ['clientName', 'method', 'uri'],
+})
+
+function normalizePath(path: string) {
+  const urlPathReplacement = '#val'
+  const urlValueParser = new UrlValueParser()
+  return urlValueParser.replacePathValues(path, urlPathReplacement)
+}
+
 export default class RestClient {
   agent: Agent
 
@@ -51,6 +74,22 @@ export default class RestClient {
     return this.config.timeout
   }
 
+  private logNetworkTimeCallback(err: Error, result: any) {
+    const url = new URL(result.url)
+    const { hostname } = url
+    const path = normalizePath(url.pathname)
+
+    console.error(err)
+    console.error(result)
+    if (err) {
+      if (err.name === 'ETIMEDOUT') {
+        timeoutCounter.labels(hostname, 'GET', path).inc()
+      }
+    }
+
+    requestHistogram.labels(hostname, 'GET', path, String(result.status)).observe(result.timings.total)
+  }
+
   retry(err?: { code: string; message: string }): void {
     if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
     return undefined // retry handler only for logging retries, not to influence retry logic
@@ -62,6 +101,7 @@ export default class RestClient {
       if (this.token) {
         result = await superagent
           .get(`${this.apiUrl()}${path}`)
+          .use(logNetworkTime(this.logNetworkTimeCallback))
           .agent(this.agent)
           .retry(2, this.retry)
           .query(query)
@@ -72,12 +112,16 @@ export default class RestClient {
       } else {
         result = await superagent
           .get(`${this.apiUrl()}${path}`)
+          .use(logNetworkTime(this.logNetworkTimeCallback))
           .agent(this.agent)
           .retry(2, this.retry)
           .query(query)
           .set(headers)
           .responseType(responseType)
           .timeout(this.timeoutConfig())
+          .on('timeout', err => {
+            console.error(err)
+          })
       }
 
       return raw ? result : result.body
@@ -102,6 +146,7 @@ export default class RestClient {
       const result = await superagent
         .post(`${this.apiUrl()}${path}`)
         .send(data)
+        .use(logNetworkTime(this.logNetworkTimeCallback))
         .agent(this.agent)
         .retry(2, (err, res) => {
           if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
@@ -131,6 +176,7 @@ export default class RestClient {
       const result = await superagent
         .patch(`${this.apiUrl()}${path}`)
         .send(data)
+        .use(logNetworkTime(this.logNetworkTimeCallback))
         .agent(this.agent)
         .retry(2, (err, res) => {
           if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
@@ -153,6 +199,7 @@ export default class RestClient {
     try {
       const result = await superagent
         .delete(`${this.apiUrl()}${path}`)
+        .use(logNetworkTime(this.logNetworkTimeCallback))
         .agent(this.agent)
         .retry(2, (err, res) => {
           if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)


### PR DESCRIPTION
This uses the `superagent-node-http-timings` package to gather the
timing data and puts all the code in `restClient`.  This works fine for
the timings, but I can't get it to handle timeouts **at all**.

IMO to the other approach is cleaner/better, we might just have to
accept that there's no test on the timeout counters, but I've already
confirmed that it's working in real use... :shrug: