### PR TITLE
Update the metrics we're generating.

### DIFF
--- a/server/clients/restClientMetricsMiddleware.ts
+++ b/server/clients/restClientMetricsMiddleware.ts
@@ -4,16 +4,16 @@ import { Response, SuperAgentRequest } from 'superagent'
 import UrlValueParser from 'url-value-parser'
 
 const requestHistogram = new promClient.Histogram({
-  name: 'http_client_requests',
+  name: 'http_client_requests_seconds',
   help: 'Timings and counts of http client requests',
   buckets: [0.5, 0.75, 0.95, 0.99, 1],
-  labelNames: ['clientName', 'method', 'uri', 'status'],
+  labelNames: ['host', 'method', 'uri', 'status'],
 })
 
 const timeoutCounter = new promClient.Counter({
-  name: 'http_client_requests_timeout',
+  name: 'http_client_requests_timeout_total',
   help: 'Count of http client request timeouts',
-  labelNames: ['clientName', 'method', 'uri'],
+  labelNames: ['host', 'method', 'uri'],
 })
 
 function restClientMetricsMiddleware(agent: SuperAgentRequest) {

--- a/server/monitoring/metricsApp.ts
+++ b/server/monitoring/metricsApp.ts
@@ -2,9 +2,11 @@ import express from 'express'
 import promBundle from 'express-prom-bundle'
 
 const metricsMiddleware = promBundle({
+  autoregister: false,
+  buckets: [0.5, 0.75, 0.95, 0.99, 1],
+  httpDurationMetricName: 'http_server_requests_seconds',
   includeMethod: true,
   includePath: true,
-  autoregister: false,
   normalizePath: [['^/assets/.+$', '/assets/#assetPath']],
 })
 


### PR DESCRIPTION
- Make the metric names the same as in the spring boot apps
- Use more correct labels

This will allow better sharing of alerts/graphs and more accurate
comparisions between applications.