### PR TITLE
Misc tech debt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
       },
       "devDependencies": {
         "@babel/core": "^7.16.7",
-        "@jest-mock/express": "^1.4.5",
         "@pact-foundation/pact": "^9.17.2",
         "@types/bunyan": "^1.8.8",
         "@types/bunyan-format": "^0.2.4",
@@ -3886,12 +3885,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@jest-mock/express": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@jest-mock/express/-/express-1.4.5.tgz",
-      "integrity": "sha512-bERM1jnutyH7VMahdaOHAKy7lgX47zJ7+RTz2eMz0wlCttd9CkhsKFEyoWmJBSz/ow0nVj3lCuRqLem4QDYFkQ==",
-      "dev": true
     },
     "node_modules/@jest/console": {
       "version": "27.4.6",
@@ -25062,12 +25055,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true
-    },
-    "@jest-mock/express": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@jest-mock/express/-/express-1.4.5.tgz",
-      "integrity": "sha512-bERM1jnutyH7VMahdaOHAKy7lgX47zJ7+RTz2eMz0wlCttd9CkhsKFEyoWmJBSz/ow0nVj3lCuRqLem4QDYFkQ==",
       "dev": true
     },
     "@jest/console": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.7",
-    "@jest-mock/express": "^1.4.5",
     "@pact-foundation/pact": "^9.17.2",
     "@types/bunyan": "^1.8.8",
     "@types/bunyan-format": "^0.2.4",

--- a/server/controllers/book/createRecall.test.ts
+++ b/server/controllers/book/createRecall.test.ts
@@ -1,11 +1,9 @@
 import { NextFunction } from 'express'
-import { mockPostRequest, mockResponseWithAuthenticatedUser } from '../testUtils/mockRequestUtils'
+import { mockReq, mockRes } from '../testUtils/mockRequestUtils'
 import { createRecall } from './createRecall'
 import { createRecall as createRecallApi, getPrisonerByNomsNumber } from '../../clients/manageRecallsApiClient'
 
 jest.mock('../../clients/manageRecallsApiClient')
-
-const userToken = { access_token: 'token-1', expires_in: 300 }
 
 describe('createRecall', () => {
   const person = {
@@ -20,8 +18,8 @@ describe('createRecall', () => {
     ;(getPrisonerByNomsNumber as jest.Mock).mockResolvedValue(person)
     ;(createRecallApi as jest.Mock).mockResolvedValue({ recallId })
 
-    const req = mockPostRequest({ body: { nomsNumber } })
-    const { res } = mockResponseWithAuthenticatedUser(userToken.access_token)
+    const req = mockReq({ method: 'POST', body: { nomsNumber } })
+    const res = mockRes()
 
     await createRecall(req, res, next)
 
@@ -33,8 +31,8 @@ describe('createRecall', () => {
     ;(getPrisonerByNomsNumber as jest.Mock).mockResolvedValue({ ...person, middleNames: 'Bryan' })
     ;(createRecallApi as jest.Mock).mockResolvedValue({ recallId })
 
-    const req = mockPostRequest({ body: { nomsNumber } })
-    const { res } = mockResponseWithAuthenticatedUser(userToken.access_token)
+    const req = mockReq({ method: 'POST', body: { nomsNumber } })
+    const res = mockRes()
 
     await createRecall(req, res, next)
 
@@ -47,8 +45,8 @@ describe('createRecall', () => {
     ;(createRecallApi as jest.Mock).mockRejectedValue(err)
     next = jest.fn()
 
-    const req = mockPostRequest({ body: { nomsNumber } })
-    const { res } = mockResponseWithAuthenticatedUser(userToken.access_token)
+    const req = mockReq({ method: 'POST', body: { nomsNumber } })
+    const res = mockRes()
 
     await createRecall(req, res, next)
     expect(next).toHaveBeenCalledWith(err)

--- a/server/controllers/changeHistory/getAllFieldsChangeHistory.ts
+++ b/server/controllers/changeHistory/getAllFieldsChangeHistory.ts
@@ -1,7 +1,6 @@
 import { NextFunction, Request, Response } from 'express'
 import { getAllFieldsHistory, getRecall } from '../../clients/manageRecallsApiClient'
 import { changeHistoryFieldList } from './helpers/recallFieldList'
-import { isString } from '../../utils/utils'
 
 export const getAllFieldsChangeHistory = async (req: Request, res: Response, next: NextFunction) => {
   const { recallId } = req.params
@@ -9,9 +8,6 @@ export const getAllFieldsChangeHistory = async (req: Request, res: Response, nex
     user: { token },
   } = res.locals
   try {
-    if (!isString(recallId)) {
-      throw new Error('Invalid recallId')
-    }
     const [fieldsHistoryResponse, recallResponse] = await Promise.allSettled([
       getAllFieldsHistory(recallId, token),
       getRecall(recallId, token),

--- a/server/controllers/changeHistory/getDocumentChangeHistory.test.ts
+++ b/server/controllers/changeHistory/getDocumentChangeHistory.test.ts
@@ -54,11 +54,6 @@ describe('getDocumentChangeHistory', () => {
 
   afterEach(() => jest.resetAllMocks())
 
-  it('returns 400 if recallId missing', () => {
-    getDocumentChangeHistory(req, res, next)
-    expect(next).toHaveBeenCalledWith(new Error('Invalid recallId'))
-  })
-
   it('returns 400 if category missing', () => {
     req.params.recallId = '456'
     req.params.nomsNumber = '123'

--- a/server/controllers/changeHistory/getDocumentChangeHistory.ts
+++ b/server/controllers/changeHistory/getDocumentChangeHistory.ts
@@ -13,9 +13,6 @@ export const getDocumentChangeHistory = async (req: Request, res: Response, next
     user: { token },
   } = res.locals
   try {
-    if (!isString(recallId)) {
-      throw new Error('Invalid recallId')
-    }
     if (!isString(category) || !findDocCategory(category as RecallDocument.category)) {
       throw new Error('Invalid category')
     }

--- a/server/controllers/changeHistory/getSingleFieldChangeHistory.test.ts
+++ b/server/controllers/changeHistory/getSingleFieldChangeHistory.test.ts
@@ -7,12 +7,6 @@ jest.mock('../../clients/manageRecallsApiClient')
 describe('getFieldChangeHistory', () => {
   afterEach(() => jest.resetAllMocks())
 
-  it('errors if recallId missing', async () => {
-    const next = mockNext()
-    await getSingleFieldChangeHistory(mockReq(), mockRes(), next)
-    expect(next).toHaveBeenCalledWith(new Error('Invalid recallId'))
-  })
-
   it('errors if fieldName is missing', async () => {
     const next = mockNext()
     await getSingleFieldChangeHistory(mockReq({ params: { recallId: '456' } }), mockRes(), next)

--- a/server/controllers/changeHistory/getSingleFieldChangeHistory.ts
+++ b/server/controllers/changeHistory/getSingleFieldChangeHistory.ts
@@ -12,9 +12,6 @@ export const getSingleFieldChangeHistory = async (req: Request, res: Response, n
     user: { token },
   } = res.locals
   try {
-    if (!isString(recallId)) {
-      throw new Error('Invalid recallId')
-    }
     if (!isString(fieldName)) {
       throw new Error('Invalid fieldName')
     }

--- a/server/controllers/testUtils/mockRequestUtils.ts
+++ b/server/controllers/testUtils/mockRequestUtils.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { getMockReq, getMockRes } from '@jest-mock/express'
 import { Request, Response } from 'express'
 import { SessionData } from 'express-session'
 import { ObjectMap, ObjectMixed } from '../../@types'
@@ -43,11 +41,13 @@ export const mockRes = ({
   token = 'token',
   redirect = jest.fn(),
   render = jest.fn(),
+  sendStatus = jest.fn(),
 }: {
   locals?: ObjectMap<unknown>
   token?: string
   redirect?: jest.Mock
   render?: jest.Mock
+  sendStatus?: jest.Mock
 } = {}): Response => {
   return {
     locals: {
@@ -60,74 +60,8 @@ export const mockRes = ({
     },
     redirect,
     render,
+    sendStatus,
   } as unknown as Response
 }
 
 export const mockNext = () => jest.fn()
-
-// all functions below this line are deprecated, use the two above if possible
-
-export function mockPostRequest({
-  body,
-  params,
-  headers,
-  session = {} as SessionData,
-  originalUrl,
-}: {
-  body?: ObjectMixed
-  params?: ObjectMixed
-  headers?: ObjectMixed
-  session?: SessionData
-  originalUrl?: string
-}) {
-  return getMockReq({
-    body,
-    params,
-    headers,
-    session,
-    originalUrl,
-  })
-}
-
-export function mockGetRequest({
-  query,
-  params,
-  session = {} as SessionData,
-  originalUrl,
-  baseUrl,
-}: {
-  query?: ObjectMixed
-  params?: ObjectMixed
-  session?: SessionData
-  originalUrl?: string
-  baseUrl?: string
-}): Request {
-  return getMockReq<Request>({
-    query,
-    params,
-    session,
-    originalUrl,
-    baseUrl,
-  })
-}
-
-export function mockResponseWithAuthenticatedUser(userAccessToken: string) {
-  return getMockRes({
-    locals: {
-      user: {
-        token: userAccessToken,
-      },
-    },
-  })
-}
-
-export function mockResponseWithAuthenticatedUserAndUserId(userAccessToken: string, userId: string) {
-  return getMockRes({
-    locals: {
-      user: {
-        token: userAccessToken,
-        uuid: userId,
-      },
-    },
-  })
-}

--- a/server/controllers/userDetails/userDetails.test.ts
+++ b/server/controllers/userDetails/userDetails.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { mockGetRequest, mockPostRequest } from '../testUtils/mockRequestUtils'
+import { mockReq } from '../testUtils/mockRequestUtils'
 import { getUser, postUser } from './userDetails'
 import { uploadStorageField } from '../documents/upload/helpers/uploadStorage'
 import { addUserDetails, getCurrentUserDetails } from '../../clients/manageRecallsApiClient'
@@ -22,7 +22,7 @@ describe('getUser', () => {
 
   it('renders the user if found', done => {
     ;(getCurrentUserDetails as jest.Mock).mockResolvedValue(userDetails)
-    const req = mockGetRequest({ originalUrl: '/user-details' })
+    const req = mockReq({ originalUrl: '/user-details' })
     const res = {
       locals: {
         user: {
@@ -74,7 +74,7 @@ describe('postUser', () => {
     ;(addUserDetails as jest.Mock).mockResolvedValue({
       userId,
     })
-    const req = mockPostRequest({ body: requestBody, originalUrl: '/user-details' })
+    const req = mockReq({ method: 'POST', body: requestBody, originalUrl: '/user-details' })
     const res = {
       locals: {
         user: {
@@ -102,7 +102,7 @@ describe('postUser', () => {
       }
       cb()
     })
-    const req = mockPostRequest({ body: requestBody, originalUrl: '/user-details' })
+    const req = mockReq({ method: 'POST', body: requestBody, originalUrl: '/user-details' })
     const res = {
       locals: {
         user: {
@@ -127,7 +127,11 @@ describe('postUser', () => {
     ;(uploadStorageField as jest.Mock).mockReturnValue((request, response, cb) => {
       cb()
     })
-    const req = mockPostRequest({ body: { existingSignature: signature }, originalUrl: '/user-details' })
+    const req = mockReq({
+      method: 'POST',
+      body: { existingSignature: signature },
+      originalUrl: '/user-details',
+    })
     const res = {
       locals: {
         user: {
@@ -178,7 +182,7 @@ describe('postUser', () => {
     ;(uploadStorageField as jest.Mock).mockReturnValue((request, response, cb) => {
       cb()
     })
-    const req = mockPostRequest({ body: requestBody, originalUrl: '/user-details' })
+    const req = mockReq({ method: 'POST', body: requestBody, originalUrl: '/user-details' })
     const res = {
       locals: {
         user: {
@@ -210,7 +214,8 @@ describe('postUser', () => {
     ;(addUserDetails as jest.Mock).mockResolvedValue({
       userId,
     })
-    const req = mockPostRequest({
+    const req = mockReq({
+      method: 'POST',
       body: { ...requestBody, existingSignature: signature },
       originalUrl: '/user-details',
     })

--- a/server/controllers/utils/lists.test.ts
+++ b/server/controllers/utils/lists.test.ts
@@ -1,4 +1,5 @@
-import { listToString, sortList } from './lists'
+import { getLatestVersionFromList, listDocumentLabels, listToString, sortList } from './lists'
+import { UploadedFileMetadata } from '../../@types/documents'
 
 describe('listToString', () => {
   it('returns a list for 1 item', () => {
@@ -32,5 +33,23 @@ describe('sortList', () => {
     const list = [{ name: 'Licence.pdf' }, { name: 'Part A.pdf' }, { name: 'OASys.pdf' }]
     const result = sortList(list, 'name', false)
     expect(result).toEqual([{ name: 'Part A.pdf' }, { name: 'OASys.pdf' }, { name: 'Licence.pdf' }])
+  })
+})
+
+describe('getLatestVersionFromList', () => {
+  it('returns the latest version', () => {
+    const latest = getLatestVersionFromList([{ version: 4 }, { version: 8 }, { version: 1 }])
+    expect(latest).toEqual({ version: 8 })
+  })
+})
+
+describe('listDocumentLabels', () => {
+  it('returns a string list', () => {
+    const result = listDocumentLabels([
+      { label: 'Part A' },
+      { label: 'Licence' },
+      { label: 'Part B' },
+    ] as UploadedFileMetadata[])
+    expect(result).toEqual('Part A, Licence and Part B')
   })
 })

--- a/server/middleware/parseUrlParams.test.ts
+++ b/server/middleware/parseUrlParams.test.ts
@@ -1,106 +1,95 @@
+import { NextFunction, Response } from 'express'
 import { parseUrlParams } from './parseUrlParams'
-import { mockGetRequest, mockResponseWithAuthenticatedUser } from '../controllers/testUtils/mockRequestUtils'
+import { mockReq, mockRes } from '../controllers/testUtils/mockRequestUtils'
 
 describe('parseUrlParams', () => {
+  let res: Response
+  let next: NextFunction
+
+  beforeEach(() => {
+    res = mockRes()
+    next = jest.fn()
+  })
+
   it('parses nomsNumber and recall ID from URL', () => {
-    const req = mockGetRequest({ params: { recallId: '123-456', pageSlug: 'last-release' } })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
+    const req = mockReq({ params: { recallId: '123-456', pageSlug: 'last-release' } })
     parseUrlParams(req, res, next)
     expect(res.locals.urlInfo).toEqual({ basePath: '/recalls/123-456/', currentPage: 'last-release' })
   })
 
   it('returns 400 if nomsNumber is invalid', () => {
-    const req = mockGetRequest({ params: { recallId: '123-456' } })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
+    const req = mockReq({ params: { recallId: '123-456' } })
     parseUrlParams(req, res, next)
     expect(res.sendStatus).toHaveBeenCalledWith(400)
   })
 
   it('returns 400 if pageSlug is missing', () => {
-    const req = mockGetRequest({ params: { recallId: '123-456' } })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
+    const req = mockReq({ params: { recallId: '123-456' } })
     parseUrlParams(req, res, next)
     expect(res.sendStatus).toHaveBeenCalledWith(400)
   })
 
   it('parses fromPage from URL for check answers page', () => {
-    const req = mockGetRequest({
+    const req = mockReq({
       params: { recallId: '123-456', pageSlug: 'last-release' },
       query: { fromPage: 'check-answers' },
     })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
     parseUrlParams(req, res, next)
     expect(res.locals.urlInfo.fromPage).toEqual('check-answers')
   })
 
   it('parses fromPage from URL for assess page', () => {
-    const req = mockGetRequest({
+    const req = mockReq({
       params: { recallId: '123-456', pageSlug: 'last-release' },
       query: { fromPage: 'assess' },
     })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
     parseUrlParams(req, res, next)
     expect(res.locals.urlInfo.fromPage).toEqual('assess')
   })
 
   it('parses fromPage from URL for dossier recall page', () => {
-    const req = mockGetRequest({
+    const req = mockReq({
       params: { recallId: '123-456', pageSlug: 'last-release' },
       query: { fromPage: 'dossier-recall' },
     })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
     parseUrlParams(req, res, next)
     expect(res.locals.urlInfo.fromPage).toEqual('dossier-recall')
   })
 
   it('parses fromPage from URL for view recall page', () => {
-    const req = mockGetRequest({
+    const req = mockReq({
       params: { recallId: '123-456', pageSlug: 'last-release' },
       query: { fromPage: 'view-recall' },
     })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
     parseUrlParams(req, res, next)
     expect(res.locals.urlInfo.fromPage).toEqual('view-recall')
   })
 
   it('parses fromPage from URL when it starts with /', () => {
-    const req = mockGetRequest({
+    const req = mockReq({
       params: { recallId: '123-456', pageSlug: 'last-release' },
       query: { fromPage: '/' },
     })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
     parseUrlParams(req, res, next)
     expect(res.locals.urlInfo.fromPage).toEqual('/')
     expect(res.locals.urlInfo.basePath).toEqual('')
   })
 
   it('parses fromHash from URL', () => {
-    const req = mockGetRequest({
+    const req = mockReq({
       params: { recallId: '123-456', pageSlug: 'last-release' },
       query: { fromHash: 'sentence' },
     })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
     parseUrlParams(req, res, next)
     expect(res.locals.urlInfo.fromHash).toEqual('sentence')
   })
 
   it('reloads the page without the query string if the fromPage param is invalid', () => {
-    const req = mockGetRequest({
+    const req = mockReq({
       params: { recallId: '123-456', pageSlug: 'last-release' },
       query: { fromPage: 'invalid-page' },
       baseUrl: '/recalls/456/start',
     })
-    const { res } = mockResponseWithAuthenticatedUser('user_access_token')
-    const next = jest.fn()
     parseUrlParams(req, res, next)
     expect(res.redirect).toHaveBeenCalledWith(req.baseUrl)
   })

--- a/server/referenceData/mappaLevels.test.ts
+++ b/server/referenceData/mappaLevels.test.ts
@@ -1,0 +1,36 @@
+import { mappaLevels } from './mappaLevels'
+import { getMappaLevels } from '../clients/manageRecallsApiClient'
+
+jest.mock('../clients/manageRecallsApiClient')
+
+describe('MAPPA levels ref data', () => {
+  ;(getMappaLevels as jest.Mock).mockResolvedValue([
+    {
+      id: 'ONE',
+      name: 'First one',
+    },
+    {
+      id: 'TWO',
+      name: 'Second one',
+    },
+  ])
+
+  it('fetches and formats a list of MAPPA levels', async () => {
+    jest.useFakeTimers()
+    const promise = mappaLevels.updateData()
+    jest.advanceTimersByTime(5000)
+    await promise.then(() => {
+      expect(mappaLevels.data).toEqual([
+        {
+          value: 'ONE',
+          text: 'First one',
+        },
+        {
+          value: 'TWO',
+          text: 'Second one',
+        },
+      ])
+      jest.useRealTimers()
+    })
+  })
+})

--- a/server/referenceData/reasonsForRecall.test.ts
+++ b/server/referenceData/reasonsForRecall.test.ts
@@ -1,0 +1,36 @@
+import { reasonsForRecall } from './reasonsForRecall'
+import { getReasonsForRecall } from '../clients/manageRecallsApiClient'
+
+jest.mock('../clients/manageRecallsApiClient')
+
+describe('Reasons for recall ref data', () => {
+  ;(getReasonsForRecall as jest.Mock).mockResolvedValue([
+    {
+      id: 'ONE',
+      name: 'First one',
+    },
+    {
+      id: 'TWO',
+      name: 'Second one',
+    },
+  ])
+
+  it('fetches and formats a list of reasons for recall', async () => {
+    jest.useFakeTimers()
+    const promise = reasonsForRecall.updateData()
+    jest.advanceTimersByTime(5000)
+    await promise.then(() => {
+      expect(reasonsForRecall.data).toEqual([
+        {
+          value: 'ONE',
+          text: 'First one',
+        },
+        {
+          value: 'TWO',
+          text: 'Second one',
+        },
+      ])
+      jest.useRealTimers()
+    })
+  })
+})

--- a/server/referenceData/stopReasons.test.ts
+++ b/server/referenceData/stopReasons.test.ts
@@ -1,0 +1,36 @@
+import { stopReasons } from './stopReasons'
+import { getStopReasons } from '../clients/manageRecallsApiClient'
+
+jest.mock('../clients/manageRecallsApiClient')
+
+describe('Stop reasons ref data', () => {
+  ;(getStopReasons as jest.Mock).mockResolvedValue([
+    {
+      id: 'ONE',
+      name: 'First one',
+    },
+    {
+      id: 'TWO',
+      name: 'Second one',
+    },
+  ])
+
+  it('fetches and formats a list of stop reasons', async () => {
+    jest.useFakeTimers()
+    const promise = stopReasons.updateData()
+    jest.advanceTimersByTime(5000)
+    await promise.then(() => {
+      expect(stopReasons.data).toEqual([
+        {
+          value: 'ONE',
+          text: 'First one',
+        },
+        {
+          value: 'TWO',
+          text: 'Second one',
+        },
+      ])
+      jest.useRealTimers()
+    })
+  })
+})

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -1,0 +1,14 @@
+import request from 'supertest'
+import appWithAllRoutes from '../controllers/testUtils/appSetup'
+
+describe('Routes', () => {
+  it('responds on a route', () => {
+    const app = appWithAllRoutes({})
+    return request(app)
+      .get('/find-person')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Find a person')
+      })
+  })
+})


### PR DESCRIPTION
- add unit tests for some uncovered areas
- remove duplicated validation of recallId (already being done by `parseUrlParams`)
- remove remaining uses of `jest-mock/express`